### PR TITLE
feat: Add "Change Password" button to Profile Screen

### DIFF
--- a/app/src/main/java/com/virtualsblog/project/presentation/ui/navigation/BlogNavGraph.kt
+++ b/app/src/main/java/com/virtualsblog/project/presentation/ui/navigation/BlogNavGraph.kt
@@ -210,7 +210,7 @@ fun BlogNavGraph(
             )
         }
 
-        // Edit Post Screen - untuk masa depan
+        // Edit Post Screen - Next Jobdesk
         /*
         composable(
             route = BlogDestinations.EDIT_POST_WITH_ID,

--- a/app/src/main/java/com/virtualsblog/project/presentation/ui/screen/auth/profile/ProfileScreen.kt
+++ b/app/src/main/java/com/virtualsblog/project/presentation/ui/screen/auth/profile/ProfileScreen.kt
@@ -16,6 +16,7 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.ArrowBack
 import androidx.compose.material.icons.filled.Edit
 import androidx.compose.material.icons.filled.ExitToApp
+import androidx.compose.material.icons.filled.Lock // Added for Change Password button
 import androidx.compose.material.icons.filled.Person
 import androidx.compose.material.icons.filled.Save
 import androidx.compose.material3.*
@@ -38,6 +39,7 @@ import com.virtualsblog.project.presentation.ui.theme.extendedColors
 fun ProfileScreen(
     onNavigateBack: () -> Unit,
     onNavigateToLogin: () -> Unit,
+    onNavigateToChangePassword: () -> Unit, // <-- Added this parameter
     viewModel: ProfileViewModel = hiltViewModel()
 ) {
     val uiState by viewModel.uiState.collectAsState()
@@ -320,9 +322,28 @@ fun ProfileScreen(
                         }
                     }
                 }
+            } else {
+                // Change Password Button (Only show when not editing profile fields)
+                Button(
+                    onClick = onNavigateToChangePassword, // Use the passed lambda
+                    modifier = Modifier.fillMaxWidth(),
+                    shape = MaterialTheme.shapes.small,
+                    colors = ButtonDefaults.buttonColors(
+                        containerColor = MaterialTheme.colorScheme.secondary
+                    )
+                ) {
+                    Icon(
+                        imageVector = Icons.Default.Lock,
+                        contentDescription = null,
+                        modifier = Modifier.size(18.dp)
+                    )
+                    Spacer(modifier = Modifier.width(8.dp))
+                    Text("Ubah Kata Sandi")
+                }
             }
 
-            Spacer(modifier = Modifier.height(32.dp))
+
+            Spacer(modifier = Modifier.height(16.dp)) // Adjusted spacing
 
             // Logout Button
             Button(


### PR DESCRIPTION
This commit introduces a "Change Password" button on the `ProfileScreen`.

**Key Changes:**

*   **`ProfileScreen.kt`:**
    *   Added a new `Button` for "Ubah Kata Sandi" (Change Password).
    *   This button is displayed when the user is not in the "edit profile fields" mode.
    *   The button uses `Icons.Default.Lock` as its icon.
    *   A new parameter `onNavigateToChangePassword: () -> Unit` was added to the `ProfileScreen` composable to handle navigation to the change password screen.
    *   Adjusted spacing around the new button.
*   **`BlogNavGraph.kt`:**
    *   A comment indicating "Edit Post Screen - Next Jobdesk" was updated from "untuk masa depan" (for the future).