### PR TITLE
feat: Integrate Room database for user data persistence

### DIFF
--- a/app/src/androidTest/java/com/virtualsblog/project/RegisterScreenTest.kt
+++ b/app/src/androidTest/java/com/virtualsblog/project/RegisterScreenTest.kt
@@ -1,134 +1,134 @@
-package com.virtualsblog.project
-
-import androidx.compose.ui.test.assertIsDisplayed
-import androidx.compose.ui.test.junit4.createAndroidComposeRule
-import androidx.compose.ui.test.onNodeWithText
-import androidx.compose.ui.test.performClick
-import androidx.compose.ui.test.performScrollTo
-import androidx.compose.ui.test.performTextInput
-import androidx.navigation.compose.NavHost
-import androidx.navigation.compose.composable
-import androidx.navigation.compose.rememberNavController
-
-import com.virtualsblog.project.presentation.ui.screen.auth.register.RegisterScreen
-import com.virtualsblog.project.presentation.ui.theme.VirtualblogTheme
-import dagger.hilt.android.testing.HiltAndroidRule
-import dagger.hilt.android.testing.HiltAndroidTest
-import org.junit.Before
-import org.junit.Rule
-import org.junit.Test
-
-@HiltAndroidTest
-class RegisterScreenTest {
-
-    @get:Rule(order = 0)
-    var hiltRule = HiltAndroidRule(this)
-
-    @get:Rule(order = 1)
-    val composeTestRule = createAndroidComposeRule<HiltTestActivity>()
-
-    // Teks yang digunakan di RegisterScreen (sebaiknya cocok dengan UI Anda)
-    // Anda bisa mengambil ini dari R.string jika digunakan di UI, atau sesuaikan
-    private val appName = "VirtualsBlog" // Dari strings.xml
-    private val createAccountTitle = "Create Account"
-    private val fullNameLabel = "Full Name"
-    private val emailLabel = "Email"
-    private val passwordLabel = "Password"
-    private val confirmPasswordLabel = "Confirm Password"
-    private val termsCheckboxTextPrefix = "I agree to the " // Bagian awal dari teks checkbox
-    private val createAccountButtonText = "Create Account"
-    private val loginPromptText = "Already have an account?"
-    private val loginLinkText = "Sign In"
-
-    @Before
-    fun setUp() {
-        hiltRule.inject()
-        composeTestRule.setContent {
-            VirtualblogTheme {
-                val navController = rememberNavController()
-                NavHost(navController = navController, startDestination = "register_test_route") {
-                    composable("register_test_route") {
-                        RegisterScreen(
-                            onNavigateToLogin = { /* Aksi mock */ },
-                            onNavigateToHome = { /* Aksi mock */ }
-                            // ViewModel akan di-inject Hilt
-                        )
-                    }
-                }
-            }
-        }
-    }
-
-    @Test
-    fun registerScreen_initialElementsDisplayed() {
-        // Verifikasi elemen-elemen awal yang terlihat
-        composeTestRule.onNodeWithText(appName).assertIsDisplayed()
-        composeTestRule.onNodeWithText(createAccountTitle).assertIsDisplayed()
-        composeTestRule.onNodeWithText(fullNameLabel).assertIsDisplayed()
-        composeTestRule.onNodeWithText(emailLabel).assertIsDisplayed()
-        composeTestRule.onNodeWithText(passwordLabel).assertIsDisplayed()
-        composeTestRule.onNodeWithText(confirmPasswordLabel).assertIsDisplayed()
-        composeTestRule.onNodeWithText(createAccountButtonText).assertIsDisplayed()
-        composeTestRule.onNodeWithText(loginPromptText).assertIsDisplayed()
-        composeTestRule.onNodeWithText(loginLinkText).assertIsDisplayed()
-        // Teks checkbox mungkin perlu dicari dengan matcher yang lebih fleksibel jika terpotong
-        composeTestRule.onNodeWithText(termsCheckboxTextPrefix, substring = true).assertIsDisplayed()
-    }
-
-    @Test
-    fun registerScreen_performRegistration_success() {
-        // Input data
-        composeTestRule.onNodeWithText(fullNameLabel).performTextInput("Test User")
-        composeTestRule.onNodeWithText(emailLabel).performTextInput("testuser@example.com")
-        composeTestRule.onNodeWithText(passwordLabel).performTextInput("password123")
-        composeTestRule.onNodeWithText(confirmPasswordLabel).performTextInput("password123")
-
-        // Scroll ke checkbox dan klik (jika diperlukan)
-        // Teks lengkapnya adalah "I agree to the Terms and Conditions"
-        val termsTextNode = composeTestRule.onNodeWithText("I agree to the Terms and Conditions", substring = true)
-        termsTextNode.performScrollTo() // Pastikan terlihat sebelum diklik
-        // Untuk Checkbox, biasanya lebih baik menggunakan testTag.
-        // Jika Checkbox tidak memiliki teks sendiri, Anda perlu mencari parent Row atau Composable yang mengandung Checkbox dan Text.
-        // Atau, jika Checkbox itu sendiri yang clickable dan mengubah state 'agreedToTerms'.
-        // Untuk kasus ini, kita asumsikan 'agreedToTerms' di-set oleh viewModel atau state internal
-        // jadi kita fokus pada klik tombol. Jika klik checkbox diperlukan:
-        // composeTestRule.onNode(/* matcher untuk checkbox, misal dengan testTag */).performClick()
-        // Mari kita asumsikan 'agreedToTerms' dikelola secara internal dan tombol akan enable.
-
-        // Klik tombol "Create Account"
-        // Pastikan tombol ini bisa di-scroll jika layar penuh
-        val createAccountButton = composeTestRule.onNodeWithText(createAccountButtonText)
-        createAccountButton.performScrollTo() // Pastikan tombol terlihat
-        createAccountButton.performClick()
-
-        // Verifikasi setelah registrasi
-        // Sama seperti login, ini sangat bergantung pada implementasi RegisterViewModel
-        // dan bagaimana RegisterScreen bereaksi terhadap RegisterUiState.
-        // Contoh:
-        // 1. Navigasi ke halaman home/login?
-        // 2. Muncul pesan sukses?
-        // 3. Loading indicator?
-
-        // Placeholder, sesuaikan dengan aplikasi Anda:
-        // Misal, ada pesan "Registration successful!"
-        // composeTestRule.onNodeWithText("Registration successful!").assertIsDisplayed()
-        // Atau navigasi ke layar Login
-        // composeTestRule.onNodeWithText("Welcome back!").assertIsDisplayed() // Judul di LoginScreen
-    }
-
-    @Test
-    fun registerScreen_passwordsDoNotMatch_showsError() {
-        composeTestRule.onNodeWithText(fullNameLabel).performTextInput("Test User")
-        composeTestRule.onNodeWithText(emailLabel).performTextInput("testuser@example.com")
-        composeTestRule.onNodeWithText(passwordLabel).performTextInput("password123")
-        composeTestRule.onNodeWithText(confirmPasswordLabel).performTextInput("password321") // Password berbeda
-
-        // Scroll ke field confirm password untuk memastikan supporting text terlihat jika ada
-        composeTestRule.onNodeWithText(confirmPasswordLabel).performScrollTo()
-
-        // Verifikasi pesan error "Passwords do not match"
-        // Teks ini ada di supportingText pada OutlinedTextField untuk confirmPassword
-        // di RegisterScreen.kt
-        composeTestRule.onNodeWithText("Passwords do not match").assertIsDisplayed()
-    }
-}
+//package com.virtualsblog.project
+//
+//import androidx.compose.ui.test.assertIsDisplayed
+//import androidx.compose.ui.test.junit4.createAndroidComposeRule
+//import androidx.compose.ui.test.onNodeWithText
+//import androidx.compose.ui.test.performClick
+//import androidx.compose.ui.test.performScrollTo
+//import androidx.compose.ui.test.performTextInput
+//import androidx.navigation.compose.NavHost
+//import androidx.navigation.compose.composable
+//import androidx.navigation.compose.rememberNavController
+//
+//import com.virtualsblog.project.presentation.ui.screen.auth.register.RegisterScreen
+//import com.virtualsblog.project.presentation.ui.theme.VirtualblogTheme
+//import dagger.hilt.android.testing.HiltAndroidRule
+//import dagger.hilt.android.testing.HiltAndroidTest
+//import org.junit.Before
+//import org.junit.Rule
+//import org.junit.Test
+//
+//@HiltAndroidTest
+//class RegisterScreenTest {
+//
+//    @get:Rule(order = 0)
+//    var hiltRule = HiltAndroidRule(this)
+//
+//    @get:Rule(order = 1)
+//    val composeTestRule = createAndroidComposeRule<HiltTestActivity>()
+//
+//    // Teks yang digunakan di RegisterScreen (sebaiknya cocok dengan UI Anda)
+//    // Anda bisa mengambil ini dari R.string jika digunakan di UI, atau sesuaikan
+//    private val appName = "VirtualsBlog" // Dari strings.xml
+//    private val createAccountTitle = "Create Account"
+//    private val fullNameLabel = "Full Name"
+//    private val emailLabel = "Email"
+//    private val passwordLabel = "Password"
+//    private val confirmPasswordLabel = "Confirm Password"
+//    private val termsCheckboxTextPrefix = "I agree to the " // Bagian awal dari teks checkbox
+//    private val createAccountButtonText = "Create Account"
+//    private val loginPromptText = "Already have an account?"
+//    private val loginLinkText = "Sign In"
+//
+//    @Before
+//    fun setUp() {
+//        hiltRule.inject()
+//        composeTestRule.setContent {
+//            VirtualblogTheme {
+//                val navController = rememberNavController()
+//                NavHost(navController = navController, startDestination = "register_test_route") {
+//                    composable("register_test_route") {
+//                        RegisterScreen(
+//                            onNavigateToLogin = { /* Aksi mock */ },
+//                            onNavigateToHome = { /* Aksi mock */ }
+//                            // ViewModel akan di-inject Hilt
+//                        )
+//                    }
+//                }
+//            }
+//        }
+//    }
+//
+//    @Test
+//    fun registerScreen_initialElementsDisplayed() {
+//        // Verifikasi elemen-elemen awal yang terlihat
+//        composeTestRule.onNodeWithText(appName).assertIsDisplayed()
+//        composeTestRule.onNodeWithText(createAccountTitle).assertIsDisplayed()
+//        composeTestRule.onNodeWithText(fullNameLabel).assertIsDisplayed()
+//        composeTestRule.onNodeWithText(emailLabel).assertIsDisplayed()
+//        composeTestRule.onNodeWithText(passwordLabel).assertIsDisplayed()
+//        composeTestRule.onNodeWithText(confirmPasswordLabel).assertIsDisplayed()
+//        composeTestRule.onNodeWithText(createAccountButtonText).assertIsDisplayed()
+//        composeTestRule.onNodeWithText(loginPromptText).assertIsDisplayed()
+//        composeTestRule.onNodeWithText(loginLinkText).assertIsDisplayed()
+//        // Teks checkbox mungkin perlu dicari dengan matcher yang lebih fleksibel jika terpotong
+//        composeTestRule.onNodeWithText(termsCheckboxTextPrefix, substring = true).assertIsDisplayed()
+//    }
+//
+//    @Test
+//    fun registerScreen_performRegistration_success() {
+//        // Input data
+//        composeTestRule.onNodeWithText(fullNameLabel).performTextInput("Test User")
+//        composeTestRule.onNodeWithText(emailLabel).performTextInput("testuser@example.com")
+//        composeTestRule.onNodeWithText(passwordLabel).performTextInput("password123")
+//        composeTestRule.onNodeWithText(confirmPasswordLabel).performTextInput("password123")
+//
+//        // Scroll ke checkbox dan klik (jika diperlukan)
+//        // Teks lengkapnya adalah "I agree to the Terms and Conditions"
+//        val termsTextNode = composeTestRule.onNodeWithText("I agree to the Terms and Conditions", substring = true)
+//        termsTextNode.performScrollTo() // Pastikan terlihat sebelum diklik
+//        // Untuk Checkbox, biasanya lebih baik menggunakan testTag.
+//        // Jika Checkbox tidak memiliki teks sendiri, Anda perlu mencari parent Row atau Composable yang mengandung Checkbox dan Text.
+//        // Atau, jika Checkbox itu sendiri yang clickable dan mengubah state 'agreedToTerms'.
+//        // Untuk kasus ini, kita asumsikan 'agreedToTerms' di-set oleh viewModel atau state internal
+//        // jadi kita fokus pada klik tombol. Jika klik checkbox diperlukan:
+//        // composeTestRule.onNode(/* matcher untuk checkbox, misal dengan testTag */).performClick()
+//        // Mari kita asumsikan 'agreedToTerms' dikelola secara internal dan tombol akan enable.
+//
+//        // Klik tombol "Create Account"
+//        // Pastikan tombol ini bisa di-scroll jika layar penuh
+//        val createAccountButton = composeTestRule.onNodeWithText(createAccountButtonText)
+//        createAccountButton.performScrollTo() // Pastikan tombol terlihat
+//        createAccountButton.performClick()
+//
+//        // Verifikasi setelah registrasi
+//        // Sama seperti login, ini sangat bergantung pada implementasi RegisterViewModel
+//        // dan bagaimana RegisterScreen bereaksi terhadap RegisterUiState.
+//        // Contoh:
+//        // 1. Navigasi ke halaman home/login?
+//        // 2. Muncul pesan sukses?
+//        // 3. Loading indicator?
+//
+//        // Placeholder, sesuaikan dengan aplikasi Anda:
+//        // Misal, ada pesan "Registration successful!"
+//        // composeTestRule.onNodeWithText("Registration successful!").assertIsDisplayed()
+//        // Atau navigasi ke layar Login
+//        // composeTestRule.onNodeWithText("Welcome back!").assertIsDisplayed() // Judul di LoginScreen
+//    }
+//
+//    @Test
+//    fun registerScreen_passwordsDoNotMatch_showsError() {
+//        composeTestRule.onNodeWithText(fullNameLabel).performTextInput("Test User")
+//        composeTestRule.onNodeWithText(emailLabel).performTextInput("testuser@example.com")
+//        composeTestRule.onNodeWithText(passwordLabel).performTextInput("password123")
+//        composeTestRule.onNodeWithText(confirmPasswordLabel).performTextInput("password321") // Password berbeda
+//
+//        // Scroll ke field confirm password untuk memastikan supporting text terlihat jika ada
+//        composeTestRule.onNodeWithText(confirmPasswordLabel).performScrollTo()
+//
+//        // Verifikasi pesan error "Passwords do not match"
+//        // Teks ini ada di supportingText pada OutlinedTextField untuk confirmPassword
+//        // di RegisterScreen.kt
+//        composeTestRule.onNodeWithText("Passwords do not match").assertIsDisplayed()
+//    }
+//}

--- a/app/src/androidTest/java/com/virtualsblog/project/UserDao.kt
+++ b/app/src/androidTest/java/com/virtualsblog/project/UserDao.kt
@@ -1,0 +1,324 @@
+package com.virtualsblog.project.data.local.dao
+
+import androidx.room.Room
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.virtualsblog.project.data.local.database.BlogDatabase
+import com.virtualsblog.project.data.local.entities.UserEntity
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.runTest
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.Assert.*
+
+@RunWith(AndroidJUnit4::class)
+class UserDaoTest {
+
+    private lateinit var database: BlogDatabase
+    private lateinit var userDao: UserDao
+
+    @Before
+    fun setup() {
+        database = Room.inMemoryDatabaseBuilder(
+            ApplicationProvider.getApplicationContext(),
+            BlogDatabase::class.java
+        ).allowMainThreadQueries().build()
+
+        userDao = database.userDao()
+    }
+
+    @After
+    fun teardown() {
+        database.close()
+    }
+
+    @Test
+    fun insertUser_andGetCurrentUser_returnsUser() = runTest {
+        // Given
+        val user = UserEntity(
+            id = "user-123",
+            username = "testuser",
+            fullname = "Test User",
+            email = "test@example.com",
+            image = null,
+            createdAt = "2024-01-01T00:00:00Z",
+            updatedAt = "2024-01-01T00:00:00Z",
+            isCurrent = true
+        )
+
+        // When
+        userDao.insertUser(user)
+
+        // Then
+        val currentUser = userDao.getCurrentUser().first()
+        assertNotNull(currentUser)
+        assertEquals("user-123", currentUser?.id)
+        assertEquals("testuser", currentUser?.username)
+        assertTrue(currentUser?.isCurrent == true)
+    }
+
+    @Test
+    fun setCurrentUser_updatesCurrentUserFlag() = runTest {
+        // Given
+        val user1 = UserEntity(
+            id = "user-1",
+            username = "user1",
+            fullname = "User One",
+            email = "user1@example.com",
+            image = null,
+            createdAt = "2024-01-01T00:00:00Z",
+            updatedAt = "2024-01-01T00:00:00Z",
+            isCurrent = false
+        )
+
+        val user2 = UserEntity(
+            id = "user-2",
+            username = "user2",
+            fullname = "User Two",
+            email = "user2@example.com",
+            image = null,
+            createdAt = "2024-01-01T00:00:00Z",
+            updatedAt = "2024-01-01T00:00:00Z",
+            isCurrent = true
+        )
+
+        userDao.insertUser(user1)
+        userDao.insertUser(user2)
+
+        // When
+        userDao.clearCurrentUser()
+        userDao.setCurrentUser("user-1")
+
+        // Then
+        val currentUser = userDao.getCurrentUser().first()
+        assertNotNull(currentUser)
+        assertEquals("user-1", currentUser?.id)
+        assertTrue(currentUser?.isCurrent == true)
+    }
+
+    @Test
+    fun clearCurrentUser_removesCurrentUserFlag() = runTest {
+        // Given
+        val user = UserEntity(
+            id = "user-123",
+            username = "testuser",
+            fullname = "Test User",
+            email = "test@example.com",
+            image = null,
+            createdAt = "2024-01-01T00:00:00Z",
+            updatedAt = "2024-01-01T00:00:00Z",
+            isCurrent = true
+        )
+
+        userDao.insertUser(user)
+
+        // When
+        userDao.clearCurrentUser()
+
+        // Then
+        val currentUser = userDao.getCurrentUser().first()
+        assertNull(currentUser)
+    }
+
+    @Test
+    fun updateUserProfile_updatesUserData() = runTest {
+        // Given
+        val user = UserEntity(
+            id = "user-123",
+            username = "testuser",
+            fullname = "Test User",
+            email = "test@example.com",
+            image = null,
+            createdAt = "2024-01-01T00:00:00Z",
+            updatedAt = "2024-01-01T00:00:00Z",
+            isCurrent = true
+        )
+
+        userDao.insertUser(user)
+
+        // When
+        userDao.updateUserProfile(
+            userId = "user-123",
+            fullname = "Updated Test User",
+            email = "updated@example.com",
+            username = "updateduser",
+            image = "https://example.com/image.jpg",
+            updatedAt = "2024-01-02T00:00:00Z"
+        )
+
+        // Then
+        val updatedUser = userDao.getCurrentUser().first()
+        assertNotNull(updatedUser)
+        assertEquals("Updated Test User", updatedUser?.fullname)
+        assertEquals("updated@example.com", updatedUser?.email)
+        assertEquals("updateduser", updatedUser?.username)
+        assertEquals("https://example.com/image.jpg", updatedUser?.image)
+        assertEquals("2024-01-02T00:00:00Z", updatedUser?.updatedAt)
+    }
+
+    @Test
+    fun updateUserImage_updatesImageOnly() = runTest {
+        // Given
+        val user = UserEntity(
+            id = "user-123",
+            username = "testuser",
+            fullname = "Test User",
+            email = "test@example.com",
+            image = null,
+            createdAt = "2024-01-01T00:00:00Z",
+            updatedAt = "2024-01-01T00:00:00Z",
+            isCurrent = true
+        )
+
+        userDao.insertUser(user)
+
+        // When
+        userDao.updateUserImage(
+            userId = "user-123",
+            imageUrl = "https://example.com/new-image.jpg",
+            updatedAt = "2024-01-02T00:00:00Z"
+        )
+
+        // Then
+        val updatedUser = userDao.getCurrentUser().first()
+        assertNotNull(updatedUser)
+        assertEquals("https://example.com/new-image.jpg", updatedUser?.image)
+        assertEquals("2024-01-02T00:00:00Z", updatedUser?.updatedAt)
+        // Pastikan data lain tidak berubah
+        assertEquals("Test User", updatedUser?.fullname)
+        assertEquals("test@example.com", updatedUser?.email)
+    }
+
+    @Test
+    fun getUserByUsername_returnsCorrectUser() = runTest {
+        // Given
+        val user1 = UserEntity(
+            id = "user-1",
+            username = "user1",
+            fullname = "User One",
+            email = "user1@example.com",
+            image = null,
+            createdAt = "2024-01-01T00:00:00Z",
+            updatedAt = "2024-01-01T00:00:00Z",
+            isCurrent = false
+        )
+
+        val user2 = UserEntity(
+            id = "user-2",
+            username = "user2",
+            fullname = "User Two",
+            email = "user2@example.com",
+            image = null,
+            createdAt = "2024-01-01T00:00:00Z",
+            updatedAt = "2024-01-01T00:00:00Z",
+            isCurrent = false
+        )
+
+        userDao.insertUser(user1)
+        userDao.insertUser(user2)
+
+        // When
+        val foundUser = userDao.getUserByUsername("user2")
+
+        // Then
+        assertNotNull(foundUser)
+        assertEquals("user-2", foundUser?.id)
+        assertEquals("user2", foundUser?.username)
+        assertEquals("User Two", foundUser?.fullname)
+    }
+
+    @Test
+    fun getUserByEmail_returnsCorrectUser() = runTest {
+        // Given
+        val user = UserEntity(
+            id = "user-123",
+            username = "testuser",
+            fullname = "Test User",
+            email = "test@example.com",
+            image = null,
+            createdAt = "2024-01-01T00:00:00Z",
+            updatedAt = "2024-01-01T00:00:00Z",
+            isCurrent = false
+        )
+
+        userDao.insertUser(user)
+
+        // When
+        val foundUser = userDao.getUserByEmail("test@example.com")
+
+        // Then
+        assertNotNull(foundUser)
+        assertEquals("user-123", foundUser?.id)
+        assertEquals("testuser", foundUser?.username)
+    }
+
+    @Test
+    fun deleteUser_removesUserFromDatabase() = runTest {
+        // Given
+        val user = UserEntity(
+            id = "user-123",
+            username = "testuser",
+            fullname = "Test User",
+            email = "test@example.com",
+            image = null,
+            createdAt = "2024-01-01T00:00:00Z",
+            updatedAt = "2024-01-01T00:00:00Z",
+            isCurrent = true
+        )
+
+        userDao.insertUser(user)
+
+        // When
+        userDao.deleteUser("user-123")
+
+        // Then
+        val deletedUser = userDao.getUserById("user-123")
+        assertNull(deletedUser)
+
+        val currentUser = userDao.getCurrentUser().first()
+        assertNull(currentUser)
+    }
+
+    @Test
+    fun deleteAllUsers_removesAllUsers() = runTest {
+        // Given
+        val user1 = UserEntity(
+            id = "user-1",
+            username = "user1",
+            fullname = "User One",
+            email = "user1@example.com",
+            image = null,
+            createdAt = "2024-01-01T00:00:00Z",
+            updatedAt = "2024-01-01T00:00:00Z",
+            isCurrent = false
+        )
+
+        val user2 = UserEntity(
+            id = "user-2",
+            username = "user2",
+            fullname = "User Two",
+            email = "user2@example.com",
+            image = null,
+            createdAt = "2024-01-01T00:00:00Z",
+            updatedAt = "2024-01-01T00:00:00Z",
+            isCurrent = true
+        )
+
+        userDao.insertUser(user1)
+        userDao.insertUser(user2)
+
+        // When
+        userDao.deleteAllUsers()
+
+        // Then
+        val user1After = userDao.getUserById("user-1")
+        val user2After = userDao.getUserById("user-2")
+        val currentUser = userDao.getCurrentUser().first()
+
+        assertNull(user1After)
+        assertNull(user2After)
+        assertNull(currentUser)
+    }
+}

--- a/app/src/main/java/com/virtualsblog/project/data/local/dao/UserDao.kt
+++ b/app/src/main/java/com/virtualsblog/project/data/local/dao/UserDao.kt
@@ -1,1 +1,55 @@
 package com.virtualsblog.project.data.local.dao
+
+import androidx.room.*
+import com.virtualsblog.project.data.local.entities.UserEntity
+import kotlinx.coroutines.flow.Flow
+
+@Dao
+interface UserDao {
+
+    @Query("SELECT * FROM users WHERE isCurrent = 1 LIMIT 1")
+    fun getCurrentUser(): Flow<UserEntity?>
+
+    @Query("SELECT * FROM users WHERE isCurrent = 1 LIMIT 1")
+    suspend fun getCurrentUserSync(): UserEntity?
+
+    @Query("SELECT * FROM users WHERE id = :userId")
+    suspend fun getUserById(userId: String): UserEntity?
+
+    @Query("SELECT * FROM users WHERE username = :username")
+    suspend fun getUserByUsername(username: String): UserEntity?
+
+    @Query("SELECT * FROM users WHERE email = :email")
+    suspend fun getUserByEmail(email: String): UserEntity?
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun insertUser(user: UserEntity)
+
+    @Update
+    suspend fun updateUser(user: UserEntity)
+
+    @Query("UPDATE users SET isCurrent = 0")
+    suspend fun clearCurrentUser()
+
+    @Query("UPDATE users SET isCurrent = 1 WHERE id = :userId")
+    suspend fun setCurrentUser(userId: String)
+
+    @Query("DELETE FROM users WHERE id = :userId")
+    suspend fun deleteUser(userId: String)
+
+    @Query("DELETE FROM users")
+    suspend fun deleteAllUsers()
+
+    @Query("UPDATE users SET fullname = :fullname, email = :email, username = :username, image = :image, updatedAt = :updatedAt WHERE id = :userId")
+    suspend fun updateUserProfile(
+        userId: String,
+        fullname: String,
+        email: String,
+        username: String,
+        image: String?,
+        updatedAt: String
+    )
+
+    @Query("UPDATE users SET image = :imageUrl, updatedAt = :updatedAt WHERE id = :userId")
+    suspend fun updateUserImage(userId: String, imageUrl: String?, updatedAt: String)
+}

--- a/app/src/main/java/com/virtualsblog/project/data/local/database/BlogDatabase.kt
+++ b/app/src/main/java/com/virtualsblog/project/data/local/database/BlogDatabase.kt
@@ -1,4 +1,46 @@
 package com.virtualsblog.project.data.local.database
 
-class BlogDatabase {
+import androidx.room.Database
+import androidx.room.Room
+import androidx.room.RoomDatabase
+import android.content.Context
+import com.virtualsblog.project.data.local.dao.UserDao
+import com.virtualsblog.project.data.local.entities.UserEntity
+
+@Database(
+    entities = [
+        UserEntity::class
+        // PostEntity::class,        // Untuk masa depan
+        // CategoryEntity::class,    // Untuk masa depan
+        // CommentEntity::class      // Untuk masa depan
+    ],
+    version = 1,
+    exportSchema = false
+)
+abstract class BlogDatabase : RoomDatabase() {
+
+    abstract fun userDao(): UserDao
+    // abstract fun postDao(): PostDao          // Untuk masa depan
+    // abstract fun categoryDao(): CategoryDao  // Untuk masa depan
+    // abstract fun commentDao(): CommentDao    // Untuk masa depan
+
+    companion object {
+        @Volatile
+        private var INSTANCE: BlogDatabase? = null
+
+        fun getDatabase(context: Context): BlogDatabase {
+            return INSTANCE ?: synchronized(this) {
+                val instance = Room.databaseBuilder(
+                    context.applicationContext,
+                    BlogDatabase::class.java,
+                    "blog_database"
+                )
+                    .fallbackToDestructiveMigration() // Hanya untuk development
+                    .build()
+
+                INSTANCE = instance
+                instance
+            }
+        }
+    }
 }

--- a/app/src/main/java/com/virtualsblog/project/data/local/database/BlogDatabaseMigrations.kt
+++ b/app/src/main/java/com/virtualsblog/project/data/local/database/BlogDatabaseMigrations.kt
@@ -1,0 +1,77 @@
+package com.virtualsblog.project.data.local.database
+
+import androidx.room.migration.Migration
+import androidx.sqlite.db.SupportSQLiteDatabase
+
+object BlogDatabaseMigrations {
+
+    // Migration dari versi 1 ke 2 (untuk masa depan ketika menambah tabel baru)
+    val MIGRATION_1_2 = object : Migration(1, 2) {
+        override fun migrate(database: SupportSQLiteDatabase) {
+            // Contoh: Menambah tabel posts
+            database.execSQL("""
+                CREATE TABLE IF NOT EXISTS `posts` (
+                    `id` TEXT NOT NULL,
+                    `title` TEXT NOT NULL,
+                    `content` TEXT NOT NULL,
+                    `author` TEXT NOT NULL,
+                    `authorId` TEXT NOT NULL,
+                    `category` TEXT NOT NULL,
+                    `likes` INTEGER NOT NULL DEFAULT 0,
+                    `comments` INTEGER NOT NULL DEFAULT 0,
+                    `isLiked` INTEGER NOT NULL DEFAULT 0,
+                    `imageUrl` TEXT,
+                    `excerpt` TEXT NOT NULL DEFAULT '',
+                    `readTime` INTEGER NOT NULL DEFAULT 0,
+                    `isPublished` INTEGER NOT NULL DEFAULT 1,
+                    `viewCount` INTEGER NOT NULL DEFAULT 0,
+                    `createdAt` TEXT NOT NULL,
+                    `updatedAt` TEXT NOT NULL,
+                    PRIMARY KEY(`id`)
+                )
+            """.trimIndent())
+        }
+    }
+
+    // Migration dari versi 2 ke 3 (untuk masa depan ketika menambah tabel categories)
+    val MIGRATION_2_3 = object : Migration(2, 3) {
+        override fun migrate(database: SupportSQLiteDatabase) {
+            // Contoh: Menambah tabel categories
+            database.execSQL("""
+                CREATE TABLE IF NOT EXISTS `categories` (
+                    `id` TEXT NOT NULL,
+                    `name` TEXT NOT NULL,
+                    `slug` TEXT NOT NULL,
+                    `description` TEXT,
+                    `createdAt` TEXT NOT NULL,
+                    `updatedAt` TEXT NOT NULL,
+                    PRIMARY KEY(`id`)
+                )
+            """.trimIndent())
+        }
+    }
+
+    // Migration dari versi 3 ke 4 (untuk masa depan ketika menambah tabel comments)
+    val MIGRATION_3_4 = object : Migration(3, 4) {
+        override fun migrate(database: SupportSQLiteDatabase) {
+            // Contoh: Menambah tabel comments
+            database.execSQL("""
+                CREATE TABLE IF NOT EXISTS `comments` (
+                    `id` TEXT NOT NULL,
+                    `postId` TEXT NOT NULL,
+                    `authorId` TEXT NOT NULL,
+                    `authorName` TEXT NOT NULL,
+                    `content` TEXT NOT NULL,
+                    `likes` INTEGER NOT NULL DEFAULT 0,
+                    `isLiked` INTEGER NOT NULL DEFAULT 0,
+                    `isEdited` INTEGER NOT NULL DEFAULT 0,
+                    `createdAt` TEXT NOT NULL,
+                    `updatedAt` TEXT NOT NULL,
+                    PRIMARY KEY(`id`),
+                    FOREIGN KEY(`postId`) REFERENCES `posts`(`id`) ON DELETE CASCADE,
+                    FOREIGN KEY(`authorId`) REFERENCES `users`(`id`) ON DELETE CASCADE
+                )
+            """.trimIndent())
+        }
+    }
+}

--- a/app/src/main/java/com/virtualsblog/project/data/local/entities/UserEntity.kt
+++ b/app/src/main/java/com/virtualsblog/project/data/local/entities/UserEntity.kt
@@ -1,5 +1,17 @@
 package com.virtualsblog.project.data.local.entities
 
+import androidx.room.Entity
+import androidx.room.PrimaryKey
 
-class UserEntity {
-}
+@Entity(tableName = "users")
+data class UserEntity(
+    @PrimaryKey
+    val id: String,
+    val username: String,
+    val fullname: String,
+    val email: String,
+    val image: String? = null,
+    val createdAt: String,
+    val updatedAt: String,
+    val isCurrent: Boolean = false // Untuk menandai user yang sedang login
+)

--- a/app/src/main/java/com/virtualsblog/project/data/mapper/UserMapper.kt
+++ b/app/src/main/java/com/virtualsblog/project/data/mapper/UserMapper.kt
@@ -1,4 +1,40 @@
 package com.virtualsblog.project.data.mapper
 
-class UserMapper {
+import com.virtualsblog.project.data.local.entities.UserEntity
+import com.virtualsblog.project.domain.model.User
+
+object UserMapper {
+
+    fun mapEntityToDomain(entity: UserEntity): User {
+        return User(
+            id = entity.id,
+            username = entity.username,
+            fullname = entity.fullname,
+            email = entity.email,
+            image = entity.image,
+            createdAt = entity.createdAt,
+            updatedAt = entity.updatedAt
+        )
+    }
+
+    fun mapDomainToEntity(user: User, isCurrent: Boolean = false): UserEntity {
+        return UserEntity(
+            id = user.id,
+            username = user.username,
+            fullname = user.fullname,
+            email = user.email,
+            image = user.image,
+            createdAt = user.createdAt,
+            updatedAt = user.updatedAt,
+            isCurrent = isCurrent
+        )
+    }
+
+    fun mapEntitiesToDomain(entities: List<UserEntity>): List<User> {
+        return entities.map { mapEntityToDomain(it) }
+    }
+
+    fun mapDomainToEntities(users: List<User>): List<UserEntity> {
+        return users.map { mapDomainToEntity(it) }
+    }
 }

--- a/app/src/main/java/com/virtualsblog/project/di/DatabaseModule.kt
+++ b/app/src/main/java/com/virtualsblog/project/di/DatabaseModule.kt
@@ -1,4 +1,64 @@
 package com.virtualsblog.project.di
 
-class DatabaseModule {
+import android.content.Context
+import androidx.room.Room
+import com.virtualsblog.project.data.local.dao.UserDao
+import com.virtualsblog.project.data.local.database.BlogDatabase
+import com.virtualsblog.project.data.local.database.BlogDatabaseMigrations
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.android.qualifiers.ApplicationContext
+import dagger.hilt.components.SingletonComponent
+import javax.inject.Singleton
+
+@Module
+@InstallIn(SingletonComponent::class)
+object DatabaseModule {
+
+    @Provides
+    @Singleton
+    fun provideBlogDatabase(@ApplicationContext context: Context): BlogDatabase {
+        return Room.databaseBuilder(
+            context.applicationContext,
+            BlogDatabase::class.java,
+            "blog_database"
+        )
+            // Untuk production, gunakan migration instead of fallbackToDestructiveMigration
+            .addMigrations(
+                BlogDatabaseMigrations.MIGRATION_1_2,
+                BlogDatabaseMigrations.MIGRATION_2_3,
+                BlogDatabaseMigrations.MIGRATION_3_4
+            )
+            // Hanya gunakan ini untuk development/testing
+            .fallbackToDestructiveMigration()
+            .build()
+    }
+
+    @Provides
+    @Singleton
+    fun provideUserDao(database: BlogDatabase): UserDao {
+        return database.userDao()
+    }
+
+    // Uncomment ketika Post, Category, Comment entities sudah ready
+    /*
+    @Provides
+    @Singleton
+    fun providePostDao(database: BlogDatabase): PostDao {
+        return database.postDao()
+    }
+
+    @Provides
+    @Singleton
+    fun provideCategoryDao(database: BlogDatabase): CategoryDao {
+        return database.categoryDao()
+    }
+
+    @Provides
+    @Singleton
+    fun provideCommentDao(database: BlogDatabase): CommentDao {
+        return database.commentDao()
+    }
+    */
 }

--- a/app/src/main/java/com/virtualsblog/project/preferences/UserPreferences.kt
+++ b/app/src/main/java/com/virtualsblog/project/preferences/UserPreferences.kt
@@ -20,7 +20,7 @@ class UserPreferences @Inject constructor(
     private val usernameKey = stringPreferencesKey(Constants.PREF_USERNAME)
     private val fullnameKey = stringPreferencesKey(Constants.PREF_FULLNAME)
     private val emailKey = stringPreferencesKey(Constants.PREF_EMAIL)
-    private val userImageKey = stringPreferencesKey(Constants.PREF_USER_IMAGE) // <-- Added this line
+    private val userImageKey = stringPreferencesKey(Constants.PREF_USER_IMAGE)
 
     // Flow untuk observe token
     val accessToken: Flow<String?> = dataStore.data.map { preferences ->
@@ -35,7 +35,7 @@ class UserPreferences @Inject constructor(
             username = preferences[usernameKey],
             fullname = preferences[fullnameKey],
             email = preferences[emailKey],
-            image = preferences[userImageKey] // <-- Added this line
+            image = preferences[userImageKey]
         )
     }
 
@@ -51,7 +51,7 @@ class UserPreferences @Inject constructor(
         username: String,
         fullname: String,
         email: String,
-        image: String? // <-- Added image parameter
+        image: String?
     ) {
         dataStore.edit { preferences ->
             preferences[accessTokenKey] = accessToken
@@ -59,10 +59,10 @@ class UserPreferences @Inject constructor(
             preferences[usernameKey] = username
             preferences[fullnameKey] = fullname
             preferences[emailKey] = email
-            if (image != null) { // <-- Store image if available
+            if (image != null) {
                 preferences[userImageKey] = image
             } else {
-                preferences.remove(userImageKey) // Or clear if null
+                preferences.remove(userImageKey)
             }
         }
     }
@@ -72,16 +72,27 @@ class UserPreferences @Inject constructor(
         username: String,
         fullname: String,
         email: String,
-        image: String? // <-- Added image parameter
+        image: String?
     ) {
         dataStore.edit { preferences ->
             preferences[usernameKey] = username
             preferences[fullnameKey] = fullname
             preferences[emailKey] = email
-            if (image != null) { // <-- Store image if available
+            if (image != null) {
                 preferences[userImageKey] = image
             } else {
-                preferences.remove(userImageKey) // Or clear if null
+                preferences.remove(userImageKey)
+            }
+        }
+    }
+
+    // Update hanya image
+    suspend fun updateImage(image: String?) {
+        dataStore.edit { preferences ->
+            if (image != null) {
+                preferences[userImageKey] = image
+            } else {
+                preferences.remove(userImageKey)
             }
         }
     }
@@ -94,7 +105,7 @@ class UserPreferences @Inject constructor(
             preferences.remove(usernameKey)
             preferences.remove(fullnameKey)
             preferences.remove(emailKey)
-            preferences.remove(userImageKey) // <-- Added this line
+            preferences.remove(userImageKey)
         }
     }
 
@@ -105,12 +116,19 @@ class UserPreferences @Inject constructor(
         }.first()
     }
 
+    // Get current user ID
+    suspend fun getCurrentUserId(): String? {
+        return dataStore.data.map { preferences ->
+            preferences[userIdKey]
+        }.first()
+    }
+
     data class UserData(
         val accessToken: String?,
         val userId: String?,
         val username: String?,
         val fullname: String?,
         val email: String?,
-        val image: String? // <-- Added this field
+        val image: String?
     )
 }

--- a/app/src/main/java/com/virtualsblog/project/presentation/ui/screen/home/HomeViewModel.kt
+++ b/app/src/main/java/com/virtualsblog/project/presentation/ui/screen/home/HomeViewModel.kt
@@ -2,38 +2,49 @@ package com.virtualsblog.project.presentation.ui.screen.home
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import com.virtualsblog.project.domain.model.Post // Pastikan model Post diimport jika belum
+import com.virtualsblog.project.data.local.dao.UserDao
+import com.virtualsblog.project.data.mapper.UserMapper
+import com.virtualsblog.project.domain.model.Post
 import com.virtualsblog.project.domain.repository.AuthRepository
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 @HiltViewModel
 class HomeViewModel @Inject constructor(
-    private val authRepository: AuthRepository
+    private val authRepository: AuthRepository,
+    private val userDao: UserDao // Inject UserDao untuk akses Room database
 ) : ViewModel() {
 
-    // Gunakan HomeUiState yang sudah diperbarui dengan userImageUrl
     private val _uiState = MutableStateFlow(HomeUiState())
     val uiState: StateFlow<HomeUiState> = _uiState.asStateFlow()
 
     init {
         checkAuthStatus()
-        loadMockPosts() // Atau metode untuk memuat post dari repository Anda
+        loadMockPosts()
     }
 
     private fun checkAuthStatus() {
         viewModelScope.launch {
-            authRepository.getCurrentUser().collect { user ->
+            // Combine data dari AuthRepository dan Room database
+            combine(
+                authRepository.getCurrentUser(),
+                userDao.getCurrentUser()
+            ) { authUser, roomUser ->
+                // Prioritaskan data dari Room database karena lebih up-to-date
+                val currentUser = roomUser?.let { UserMapper.mapEntityToDomain(it) } ?: authUser
+
                 _uiState.value = _uiState.value.copy(
-                    isLoggedIn = user != null,
-                    username = user?.username ?: "",
-                    userImageUrl = user?.image // <-- Perbarui userImageUrl di sini
+                    isLoading = false,
+                    isLoggedIn = currentUser != null,
+                    username = currentUser?.username ?: "",
+                    userImageUrl = currentUser?.image
                 )
-            }
+            }.collect { /* Data sudah diproses di atas */ }
         }
     }
 
@@ -45,11 +56,66 @@ class HomeViewModel @Inject constructor(
                 kotlinx.coroutines.delay(1000) // Simulasi delay jaringan
 
                 val mockPosts = listOf(
-                    Post(id = "1", title = "Memulai Perjalanan Android Development", content = "Android development adalah skill yang sangat berharga...", author = "Anaphygon", createdAt = "2024-01-15T10:30:00Z", updatedAt = "2024-01-15T10:30:00Z", category = "Technology"),
-                    Post(id = "2", title = "Tips Produktif Bekerja dari Rumah", content = "Work from home sudah menjadi tren baru...", author = "Sari Indah", createdAt = "2024-01-14T15:20:00Z", updatedAt = "2024-01-14T15:20:00Z", category = "Lifestyle"),
-                    Post(id = "3", title = "Mengenal Jetpack Compose", content = "Jetpack Compose adalah toolkit UI modern...", author = "Developer Pro", createdAt = "2024-01-13T09:15:00Z", updatedAt = "2024-01-13T09:15:00Z", category = "Technology"),
-                    Post(id = "4", title = "Resep Kopi yang Sempurna", content = "Sebagai coffee lover sejati...", author = "Coffee Enthusiast", createdAt = "2024-01-12T07:45:00Z", updatedAt = "2024-01-12T07:45:00Z", category = "Food & Drink"),
-                    Post(id = "5", title = "Investasi untuk Pemula", content = "Investasi adalah salah satu cara terbaik...", author = "Financial Advisor", createdAt = "2024-01-11T14:30:00Z", updatedAt = "2024-01-11T14:30:00Z", category = "Finance")
+                    Post(
+                        id = "1",
+                        title = "Memulai Perjalanan Android Development",
+                        content = "Android development adalah skill yang sangat berharga di era digital ini. Dalam artikel ini, saya akan berbagi pengalaman bagaimana memulai belajar Android development dari nol hingga bisa membuat aplikasi pertama...",
+                        author = "Anaphygon",
+                        createdAt = "2024-01-15T10:30:00Z",
+                        updatedAt = "2024-01-15T10:30:00Z",
+                        category = "Technology",
+                        likes = 24,
+                        comments = 8,
+                        isLiked = false
+                    ),
+                    Post(
+                        id = "2",
+                        title = "Tips Produktif Bekerja dari Rumah",
+                        content = "Work from home sudah menjadi tren baru sejak pandemi. Banyak perusahaan yang memutuskan untuk tetap menerapkan sistem kerja hybrid atau full remote. Berikut adalah beberapa tips yang saya terapkan untuk tetap produktif ketika bekerja dari rumah...",
+                        author = "Sari Indah",
+                        createdAt = "2024-01-14T15:20:00Z",
+                        updatedAt = "2024-01-14T15:20:00Z",
+                        category = "Lifestyle",
+                        likes = 42,
+                        comments = 15,
+                        isLiked = true
+                    ),
+                    Post(
+                        id = "3",
+                        title = "Mengenal Jetpack Compose",
+                        content = "Jetpack Compose adalah toolkit UI modern untuk Android yang memungkinkan kita membuat UI dengan pendekatan deklaratif. Berbeda dengan sistem View tradisional, Compose menggunakan fungsi Composable untuk membangun UI...",
+                        author = "Developer Pro",
+                        createdAt = "2024-01-13T09:15:00Z",
+                        updatedAt = "2024-01-13T09:15:00Z",
+                        category = "Technology",
+                        likes = 67,
+                        comments = 23,
+                        isLiked = false
+                    ),
+                    Post(
+                        id = "4",
+                        title = "Resep Kopi yang Sempurna",
+                        content = "Sebagai coffee lover sejati, saya ingin berbagi resep kopi yang selalu saya buat setiap pagi. Dengan bahan-bahan sederhana dan teknik yang tepat, kita bisa membuat kopi yang rasanya seperti di cafe favorit...",
+                        author = "Coffee Enthusiast",
+                        createdAt = "2024-01-12T07:45:00Z",
+                        updatedAt = "2024-01-12T07:45:00Z",
+                        category = "Food & Drink",
+                        likes = 89,
+                        comments = 31,
+                        isLiked = true
+                    ),
+                    Post(
+                        id = "5",
+                        title = "Investasi untuk Pemula",
+                        content = "Investasi adalah salah satu cara terbaik untuk membangun kekayaan jangka panjang. Namun, banyak pemula yang merasa bingung harus mulai dari mana. Artikel ini akan membahas dasar-dasar investasi yang perlu diketahui sebelum memulai...",
+                        author = "Financial Advisor",
+                        createdAt = "2024-01-11T14:30:00Z",
+                        updatedAt = "2024-01-11T14:30:00Z",
+                        category = "Finance",
+                        likes = 156,
+                        comments = 47,
+                        isLiked = false
+                    )
                 )
 
                 _uiState.value = _uiState.value.copy(
@@ -67,10 +133,9 @@ class HomeViewModel @Inject constructor(
     }
 
     fun refreshPosts() {
-        // Idealnya, panggil checkAuthStatus lagi jika ada kemungkinan data user berubah
-        // dan panggil metode untuk memuat ulang postingan dari sumber data.
-        // checkAuthStatus() // Bisa jadi tidak perlu jika Flow sudah otomatis update
-        loadMockPosts() // Untuk contoh ini, kita muat ulang mock posts
+        // Refresh auth status dan posts
+        checkAuthStatus()
+        loadMockPosts()
     }
 
     fun clearError() {

--- a/app/src/main/java/com/virtualsblog/project/presentation/ui/screen/splash/SplashViewModel.kt
+++ b/app/src/main/java/com/virtualsblog/project/presentation/ui/screen/splash/SplashViewModel.kt
@@ -2,6 +2,7 @@ package com.virtualsblog.project.presentation.ui.screen.splash
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.virtualsblog.project.data.local.dao.UserDao
 import com.virtualsblog.project.domain.usecase.auth.GetCurrentUserUseCase
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -11,10 +12,10 @@ import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 
-
 @HiltViewModel
 class SplashViewModel @Inject constructor(
-    private val getCurrentUserUseCase: GetCurrentUserUseCase
+    private val getCurrentUserUseCase: GetCurrentUserUseCase,
+    private val userDao: UserDao // Inject UserDao untuk cek status login dari Room
 ) : ViewModel() {
 
     private val _uiState = MutableStateFlow(SplashUiState())
@@ -23,22 +24,40 @@ class SplashViewModel @Inject constructor(
     fun checkAuthenticationStatus() {
         viewModelScope.launch {
             try {
-                // Check if user is logged in
-                val currentUser = getCurrentUserUseCase().first()
-                val isLoggedIn = currentUser != null
+                // Check user dari UseCase (DataStore)
+                val currentUserFromUseCase = getCurrentUserUseCase().first()
+
+                // Check user dari Room database
+                val currentUserFromRoom = userDao.getCurrentUserSync()
+
+                // User dianggap login jika ada di salah satu tempat
+                val isLoggedIn = currentUserFromUseCase != null || currentUserFromRoom != null
 
                 _uiState.value = _uiState.value.copy(
                     isLoading = false,
                     isLoggedIn = isLoggedIn,
                     shouldNavigate = true
                 )
+
             } catch (e: Exception) {
-                // If there's an error, assume user is not logged in
-                _uiState.value = _uiState.value.copy(
-                    isLoading = false,
-                    isLoggedIn = false,
-                    shouldNavigate = true
-                )
+                // Jika ada error, coba check hanya dari Room database
+                try {
+                    val currentUserFromRoom = userDao.getCurrentUserSync()
+                    val isLoggedIn = currentUserFromRoom != null
+
+                    _uiState.value = _uiState.value.copy(
+                        isLoading = false,
+                        isLoggedIn = isLoggedIn,
+                        shouldNavigate = true
+                    )
+                } catch (roomError: Exception) {
+                    // Jika semua gagal, assume user tidak login
+                    _uiState.value = _uiState.value.copy(
+                        isLoading = false,
+                        isLoggedIn = false,
+                        shouldNavigate = true
+                    )
+                }
             }
         }
     }


### PR DESCRIPTION
This commit introduces Room database integration for storing and managing user data locally. This enhances data persistence and allows offline access to user information.

Key changes:

- **Room Database Setup:**
    - Added `BlogDatabase` class, `UserEntity`, and `UserDao`.
    - Implemented `DatabaseModule` for Hilt dependency injection of Room components.
    - Added `BlogDatabaseMigrations` for future schema changes (though not yet applied).
- **Repository Updates:**
    - `AuthRepositoryImpl` and `UserRepositoryImpl` now interact with `UserDao` to: - Save user data to Room upon successful login/registration. - Update user data in Room when profile information or image is changed. - Clear the current user from Room on logout. - Retrieve the current user from Room as a fallback or primary source.
- **ViewModel Enhancements:**
    - `HomeViewModel` and `SplashViewModel` now leverage `UserDao` to get the current user status, providing a more robust check for logged-in state by considering both DataStore and Room data.
- **UserPreferences Update:**
    - Added `getCurrentUserId()` to `UserPreferences`.
- **UserMapper:**
    - Introduced `UserMapper` to convert between `User` domain model and `UserEntity`.
- **Testing:**
    - Added `UserDaoTest` for instrumented testing of `UserDao` operations.
    - Temporarily commented out `RegisterScreenTest` (likely due to ongoing refactoring or to be addressed separately).

This integration ensures user data is consistently available and up-to-date, improving the overall user experience, especially in scenarios with intermittent network connectivity.