### PR TITLE
feat: Enhance image and comment interaction in PostDetailScreen

### DIFF
--- a/app/src/main/java/com/virtualsblog/project/presentation/ui/component/CommentItem.kt
+++ b/app/src/main/java/com/virtualsblog/project/presentation/ui/component/CommentItem.kt
@@ -13,12 +13,14 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import com.virtualsblog.project.domain.model.Comment
 import com.virtualsblog.project.util.DateUtil
+import com.virtualsblog.project.util.ImageUtil
 
 @Composable
 fun CommentItem(
     comment: Comment,
     currentUserId: String?,
     onDeleteClick: (() -> Unit)? = null,
+    onAvatarClick: ((String?) -> Unit)? = null, // Added callback for avatar click
     modifier: Modifier = Modifier
 ) {
     var showDropdown by remember { mutableStateOf(false) }
@@ -40,14 +42,15 @@ fun CommentItem(
                 modifier = Modifier.fillMaxWidth(),
                 verticalAlignment = Alignment.CenterVertically
             ) {
-                // Author Avatar
+                // Author Avatar - Made clickable
                 UserAvatar(
                     userName = comment.authorName,
                     imageUrl = comment.authorImage,
                     size = 36.dp,
                     showBorder = true,
                     borderColor = MaterialTheme.colorScheme.primary.copy(alpha = 0.3f),
-                    borderWidth = 1.dp
+                    borderWidth = 1.dp,
+                    onClick = { onAvatarClick?.invoke(comment.authorImage) } // Invoke callback
                 )
 
                 Spacer(modifier = Modifier.width(12.dp))


### PR DESCRIPTION
This commit introduces several enhancements to the `PostDetailScreen`:

**Image Interaction:**
- Implemented full-screen image viewing for:
    - Post hero image
    - Author avatar
    - Commenter avatars
- Added `onImageClick` to `HeroImageSection` and `onAvatarClick` to `EnhancedAuthorSection` and `CommentItem` to trigger full-screen view.
- Utilized `ImageUtil` for consistent image URL handling.

**Comment Section:**
- Added expand/collapse functionality to the comments section with an animation.
- Implemented pagination for comments, displaying 10 comments per page.
    - Added "Previous" and "Next" buttons for navigation.
    - Displays current page and total pages.
    - Resets to the first page after sending a new comment.
- `CommentItem` now accepts an `onAvatarClick` callback to enable full-screen viewing of commenter avatars.

**Minor Changes:**
- Updated content description for the hero image to include the post title.
- Adjusted spacing in the comment section.