### PR TITLE
feat: Implement category Browse and global search features

### DIFF
--- a/app/src/main/java/com/virtualsblog/project/data/remote/api/BlogApi.kt
+++ b/app/src/main/java/com/virtualsblog/project/data/remote/api/BlogApi.kt
@@ -27,6 +27,19 @@ interface BlogApi {
         @Header(Constants.HEADER_AUTHORIZATION) authorization: String
     ): Response<CategoriesApiResponse>
 
+    @GET("categories/{id}")
+    suspend fun getPostsByCategoryId(
+        @Path("id") categoryId: String,
+        @Header(Constants.HEADER_AUTHORIZATION) authorization: String
+    ): Response<PostsApiResponse>
+
+    // *** NEW SEARCH FUNCTION ***
+    @GET("search")
+    suspend fun search(
+        @Query("keyword") keyword: String,
+        @Header(Constants.HEADER_AUTHORIZATION) authorization: String
+    ): Response<ApiResponse<SearchResponseData>> //
+
     @Multipart
     @POST("posts")
     suspend fun createPost(
@@ -45,7 +58,7 @@ interface BlogApi {
         @Part("title") title: RequestBody,
         @Part("content") content: RequestBody,
         @Part("categoryId") categoryId: RequestBody,
-        @Part photo: MultipartBody.Part? // Photo is optional for update
+        @Part photo: MultipartBody.Part?
     ): Response<ApiResponse<PostResponse>>
 
     @DELETE("posts/{id}")
@@ -54,7 +67,6 @@ interface BlogApi {
         @Header("Authorization") authorization: String
     ): Response<ApiResponse<PostResponse>>
 
-    // COMMENT ENDPOINTS
     @POST("posts/{id}/comments")
     suspend fun createComment(
         @Path("id") postId: String,
@@ -68,10 +80,9 @@ interface BlogApi {
         @Header(Constants.HEADER_AUTHORIZATION) authorization: String
     ): Response<CommentApiResponse>
 
-    // UPDATED: Like endpoint with correct response type
     @POST("posts/{id}/likes")
     suspend fun toggleLike(
         @Path("id") postId: String,
         @Header(Constants.HEADER_AUTHORIZATION) authorization: String
-    ): Response<LikeToggleResponse> // Uses the updated response structure
+    ): Response<LikeToggleResponse>
 }

--- a/app/src/main/java/com/virtualsblog/project/data/remote/dto/response/SearchResponseData.kt
+++ b/app/src/main/java/com/virtualsblog/project/data/remote/dto/response/SearchResponseData.kt
@@ -1,0 +1,13 @@
+package com.virtualsblog.project.data.remote.dto.response
+
+import com.google.gson.annotations.SerializedName
+
+// This DTO directly matches the 'data' object in the search API response
+data class SearchResponseData(
+    @SerializedName("users")
+    val users: List<UserResponse> = emptyList(),
+    @SerializedName("categories")
+    val categories: List<CategoryResponse> = emptyList(),
+    @SerializedName("posts")
+    val posts: List<PostResponse> = emptyList()
+)

--- a/app/src/main/java/com/virtualsblog/project/di/UseCaseModule.kt
+++ b/app/src/main/java/com/virtualsblog/project/di/UseCaseModule.kt
@@ -17,6 +17,8 @@ import com.virtualsblog.project.domain.usecase.blog.CreatePostUseCase // Make su
 import com.virtualsblog.project.domain.usecase.blog.UpdatePostUseCase // New
 import com.virtualsblog.project.domain.usecase.blog.DeletePostUseCase // New
 import com.virtualsblog.project.domain.usecase.blog.GetCategoriesUseCase // Make sure this is imported
+import com.virtualsblog.project.domain.usecase.blog.GetPostsByCategoryIdUseCase // *** NEW IMPORT ***
+import com.virtualsblog.project.domain.usecase.blog.SearchUseCase
 import com.virtualsblog.project.domain.usecase.comment.CreateCommentUseCase
 import com.virtualsblog.project.domain.usecase.comment.DeleteCommentUseCase
 
@@ -103,6 +105,14 @@ object UseCaseModule {
     @Singleton
     fun provideGetCategoriesUseCase(repository: BlogRepository): GetCategoriesUseCase = GetCategoriesUseCase(repository) // Ensure this exists
 
+    // *** NEW USE CASE PROVIDER ***
+    @Provides
+    @Singleton
+    fun provideGetPostsByCategoryIdUseCase(repository: BlogRepository): GetPostsByCategoryIdUseCase = GetPostsByCategoryIdUseCase(repository)
+
+    @Provides
+    @Singleton
+    fun provideSearchUseCase(repository: BlogRepository): SearchUseCase = SearchUseCase(repository)
 
     // New Blog UseCases for Edit and Delete
     @Provides

--- a/app/src/main/java/com/virtualsblog/project/domain/model/SearchData.kt
+++ b/app/src/main/java/com/virtualsblog/project/domain/model/SearchData.kt
@@ -1,0 +1,7 @@
+package com.virtualsblog.project.domain.model
+
+data class SearchData(
+    val users: List<User>,
+    val categories: List<Category>,
+    val posts: List<Post>
+)

--- a/app/src/main/java/com/virtualsblog/project/domain/repository/BlogRepository.kt
+++ b/app/src/main/java/com/virtualsblog/project/domain/repository/BlogRepository.kt
@@ -4,6 +4,7 @@ package com.virtualsblog.project.domain.repository
 import com.virtualsblog.project.domain.model.Category
 import com.virtualsblog.project.domain.model.Comment
 import com.virtualsblog.project.domain.model.Post
+import com.virtualsblog.project.domain.model.SearchData
 import com.virtualsblog.project.util.Resource
 import kotlinx.coroutines.flow.Flow
 import java.io.File
@@ -14,6 +15,12 @@ interface BlogRepository {
     suspend fun getTotalPostsCount(): Flow<Resource<Int>>
     suspend fun getPostById(postId: String): Flow<Resource<Post>>
     suspend fun getCategories(): Flow<Resource<List<Category>>>
+
+
+    suspend fun getPostsByCategoryId(categoryId: String): Flow<Resource<List<Post>>>
+
+    suspend fun search(keyword: String): Flow<Resource<SearchData>>
+
     suspend fun createPost(
         title: String,
         content: String,

--- a/app/src/main/java/com/virtualsblog/project/domain/usecase/blog/GetPostsByCategoryIdUseCase.kt
+++ b/app/src/main/java/com/virtualsblog/project/domain/usecase/blog/GetPostsByCategoryIdUseCase.kt
@@ -1,0 +1,18 @@
+package com.virtualsblog.project.domain.usecase.blog
+
+import com.virtualsblog.project.domain.model.Post
+import com.virtualsblog.project.domain.repository.BlogRepository
+import com.virtualsblog.project.util.Resource
+import kotlinx.coroutines.flow.Flow
+import javax.inject.Inject
+
+class GetPostsByCategoryIdUseCase @Inject constructor(
+    private val repository: BlogRepository
+) {
+    suspend operator fun invoke(categoryId: String): Flow<Resource<List<Post>>> {
+        if (categoryId.isBlank()) {
+            return kotlinx.coroutines.flow.flow { emit(Resource.Error("ID Kategori tidak boleh kosong.")) }
+        }
+        return repository.getPostsByCategoryId(categoryId)
+    }
+}

--- a/app/src/main/java/com/virtualsblog/project/domain/usecase/blog/SearchUseCase.kt
+++ b/app/src/main/java/com/virtualsblog/project/domain/usecase/blog/SearchUseCase.kt
@@ -1,0 +1,22 @@
+package com.virtualsblog.project.domain.usecase.blog
+
+import com.virtualsblog.project.domain.model.SearchData
+import com.virtualsblog.project.domain.repository.BlogRepository
+import com.virtualsblog.project.util.Resource
+import kotlinx.coroutines.flow.Flow
+import javax.inject.Inject
+
+class SearchUseCase @Inject constructor(
+    private val repository: BlogRepository
+) {
+    suspend operator fun invoke(keyword: String): Flow<Resource<SearchData>> {
+        if (keyword.isBlank()) {
+            return kotlinx.coroutines.flow.flow { emit(Resource.Error("Keyword tidak boleh kosong.")) }
+        }
+        // Minimum keyword length check if needed by API (docs say min 1 char for query param)
+        if (keyword.length < 1) {
+            return kotlinx.coroutines.flow.flow { emit(Resource.Error("Keyword minimal 1 karakter.")) }
+        }
+        return repository.search(keyword)
+    }
+}

--- a/app/src/main/java/com/virtualsblog/project/presentation/ui/navigation/BlogDestinations.kt
+++ b/app/src/main/java/com/virtualsblog/project/presentation/ui/navigation/BlogDestinations.kt
@@ -19,18 +19,30 @@ object BlogDestinations {
     const val POST_DETAIL_ROUTE = "post_detail"
     const val EDIT_POST_ROUTE = "edit_post"
     const val TERMS_AND_CONDITIONS_ROUTE = "terms_and_conditions"
+    // *** NEW ROUTES ***
+    const val CATEGORIES_ROUTE = "categories"
+    const val CATEGORY_POSTS_ROUTE = "category_posts"
+    const val SEARCH_ROUTE = "search" // *** NEW ROUTE ***
+
+
 
     // Routes with parameters
     const val VERIFY_OTP_WITH_EMAIL = "$VERIFY_OTP_ROUTE/{${Args.EMAIL}}"
     const val RESET_PASSWORD_WITH_PARAMS = "$RESET_PASSWORD_ROUTE/{${Args.TOKEN_ID}}/{${Args.OTP}}"
     const val POST_DETAIL_WITH_ID = "$POST_DETAIL_ROUTE/{${Args.POST_ID}}"
     const val EDIT_POST_WITH_ID = "$EDIT_POST_ROUTE/{${Args.POST_ID}}"
+    // *** NEW ROUTE WITH PARAMETERS ***
+    const val CATEGORY_POSTS_WITH_ID_AND_NAME = "$CATEGORY_POSTS_ROUTE/{${Args.CATEGORY_ID}}/{${Args.CATEGORY_NAME}}"
+
 
     // Helper functions to create routes with parameters
     fun verifyOtpRoute(email: String) = "$VERIFY_OTP_ROUTE/$email"
     fun resetPasswordRoute(tokenId: String, otp: String) = "$RESET_PASSWORD_ROUTE/$tokenId/$otp"
     fun postDetailRoute(postId: String) = "$POST_DETAIL_ROUTE/$postId"
     fun editPostRoute(postId: String) = "$EDIT_POST_ROUTE/$postId"
+    // *** NEW HELPER FUNCTION ***
+    fun categoryPostsRoute(categoryId: String, categoryName: String) = "$CATEGORY_POSTS_ROUTE/$categoryId/$categoryName"
+
 
     // Auth-specific nested routes
     object Auth {
@@ -48,5 +60,8 @@ object BlogDestinations {
         const val TOKEN_ID = "tokenId"
         const val OTP = "otp"
         const val POST_ID = "postId"
+        // *** NEW ARGS ***
+        const val CATEGORY_ID = "categoryId"
+        const val CATEGORY_NAME = "categoryName"
     }
 }

--- a/app/src/main/java/com/virtualsblog/project/presentation/ui/screen/category/list/CategoriesScreen.kt
+++ b/app/src/main/java/com/virtualsblog/project/presentation/ui/screen/category/list/CategoriesScreen.kt
@@ -1,0 +1,130 @@
+package com.virtualsblog.project.presentation.ui.screen.category.list
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.ArrowBack
+import androidx.compose.material.icons.filled.Category
+import androidx.compose.material.icons.automirrored.filled.KeyboardArrowRight
+import androidx.compose.material3.*
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import com.virtualsblog.project.domain.model.Category
+import com.virtualsblog.project.presentation.ui.component.LoadingIndicator
+import com.virtualsblog.project.presentation.ui.component.ErrorMessage
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun CategoriesScreen(
+    onNavigateBack: () -> Unit,
+    onNavigateToCategoryPosts: (categoryId: String, categoryName: String) -> Unit,
+    viewModel: CategoriesViewModel = hiltViewModel()
+) {
+    val uiState by viewModel.uiState.collectAsState()
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text("Semua Kategori", fontWeight = FontWeight.Bold) },
+                navigationIcon = {
+                    IconButton(onClick = onNavigateBack) {
+                        Icon(Icons.Default.ArrowBack, contentDescription = "Kembali")
+                    }
+                },
+                colors = TopAppBarDefaults.topAppBarColors(
+                    containerColor = MaterialTheme.colorScheme.surface,
+                    titleContentColor = MaterialTheme.colorScheme.onSurface
+                )
+            )
+        }
+    ) { paddingValues ->
+        Box(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(paddingValues)
+                .background(MaterialTheme.colorScheme.background)
+        ) {
+            when {
+                uiState.isLoading -> LoadingIndicator(message = "Memuat kategori...")
+                uiState.error != null -> ErrorMessage(
+                    message = uiState.error!!,
+                    onRetry = { viewModel.loadCategories() },
+                    modifier = Modifier.padding(16.dp)
+                )
+                uiState.categories.isEmpty() -> {
+                    Box(modifier = Modifier.fillMaxSize().padding(16.dp), contentAlignment = Alignment.Center) {
+                        Text("Belum ada kategori.", style = MaterialTheme.typography.bodyLarge)
+                    }
+                }
+                else -> {
+                    LazyColumn(
+                        contentPadding = PaddingValues(16.dp),
+                        verticalArrangement = Arrangement.spacedBy(12.dp)
+                    ) {
+                        items(uiState.categories, key = { it.id }) { category ->
+                            CategoryListItem(
+                                category = category,
+                                onClick = {
+                                    onNavigateToCategoryPosts(category.id, category.name)
+                                }
+                            )
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun CategoryListItem(
+    category: Category,
+    onClick: () -> Unit
+) {
+    Card(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clickable(onClick = onClick),
+        shape = MaterialTheme.shapes.medium,
+        colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surfaceVariant),
+        elevation = CardDefaults.cardElevation(defaultElevation = 1.dp)
+    ) {
+        Row(
+            modifier = Modifier
+                .padding(horizontal = 16.dp, vertical = 20.dp)
+                .fillMaxWidth(),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.SpaceBetween
+        ) {
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                Icon(
+                    imageVector = Icons.Default.Category,
+                    contentDescription = "Ikon Kategori",
+                    tint = MaterialTheme.colorScheme.primary,
+                    modifier = Modifier.size(28.dp)
+                )
+                Spacer(modifier = Modifier.width(16.dp))
+                Text(
+                    text = category.name,
+                    style = MaterialTheme.typography.titleMedium,
+                    fontWeight = FontWeight.SemiBold,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+            }
+            Icon(
+                imageVector = Icons.AutoMirrored.Filled.KeyboardArrowRight,
+                contentDescription = "Lihat Postingan Kategori",
+                tint = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.7f)
+            )
+        }
+    }
+}

--- a/app/src/main/java/com/virtualsblog/project/presentation/ui/screen/category/list/CategoriesUiState.kt
+++ b/app/src/main/java/com/virtualsblog/project/presentation/ui/screen/category/list/CategoriesUiState.kt
@@ -1,0 +1,9 @@
+package com.virtualsblog.project.presentation.ui.screen.category.list
+
+import com.virtualsblog.project.domain.model.Category
+
+data class CategoriesUiState(
+    val isLoading: Boolean = false,
+    val categories: List<Category> = emptyList(),
+    val error: String? = null
+)

--- a/app/src/main/java/com/virtualsblog/project/presentation/ui/screen/category/list/CategoriesViewModel.kt
+++ b/app/src/main/java/com/virtualsblog/project/presentation/ui/screen/category/list/CategoriesViewModel.kt
@@ -1,0 +1,55 @@
+package com.virtualsblog.project.presentation.ui.screen.category.list
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.virtualsblog.project.domain.usecase.blog.GetCategoriesUseCase
+import com.virtualsblog.project.util.Resource
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+@HiltViewModel
+class CategoriesViewModel @Inject constructor(
+    private val getCategoriesUseCase: GetCategoriesUseCase
+) : ViewModel() {
+
+    private val _uiState = MutableStateFlow(CategoriesUiState())
+    val uiState: StateFlow<CategoriesUiState> = _uiState.asStateFlow()
+
+    init {
+        loadCategories()
+    }
+
+    fun loadCategories() {
+        viewModelScope.launch {
+            _uiState.value = _uiState.value.copy(isLoading = true, error = null)
+            getCategoriesUseCase().collect { result ->
+                when (result) {
+                    is Resource.Success -> {
+                        _uiState.value = _uiState.value.copy(
+                            isLoading = false,
+                            categories = result.data ?: emptyList(),
+                            error = null
+                        )
+                    }
+                    is Resource.Error -> {
+                        _uiState.value = _uiState.value.copy(
+                            isLoading = false,
+                            error = result.message ?: "Gagal memuat kategori."
+                        )
+                    }
+                    is Resource.Loading -> {
+                        _uiState.value = _uiState.value.copy(isLoading = true)
+                    }
+                }
+            }
+        }
+    }
+
+    fun clearError() {
+        _uiState.value = _uiState.value.copy(error = null)
+    }
+}

--- a/app/src/main/java/com/virtualsblog/project/presentation/ui/screen/category/posts/CategoryPostsScreen.kt
+++ b/app/src/main/java/com/virtualsblog/project/presentation/ui/screen/category/posts/CategoryPostsScreen.kt
@@ -1,0 +1,138 @@
+package com.virtualsblog.project.presentation.ui.screen.category.posts
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.ArrowBack
+import androidx.compose.material.icons.filled.HeartBroken
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import com.virtualsblog.project.presentation.ui.component.PostCard
+import com.virtualsblog.project.presentation.ui.component.LoadingIndicator
+import com.virtualsblog.project.presentation.ui.component.ErrorMessage
+import androidx.compose.material.ExperimentalMaterialApi
+import androidx.compose.material.pullrefresh.PullRefreshIndicator
+import androidx.compose.material.pullrefresh.pullRefresh
+import androidx.compose.material.pullrefresh.rememberPullRefreshState
+import com.virtualsblog.project.util.Constants
+
+@OptIn(ExperimentalMaterial3Api::class, ExperimentalMaterialApi::class)
+@Composable
+fun CategoryPostsScreen(
+    categoryName: String,
+    onNavigateBack: () -> Unit,
+    onNavigateToPostDetail: (String) -> Unit,
+    viewModel: CategoryPostsViewModel = hiltViewModel()
+) {
+    val uiState by viewModel.uiState.collectAsState()
+    val pullRefreshState = rememberPullRefreshState(
+        refreshing = uiState.isLoading && uiState.posts.isNotEmpty(), // Show pull refresh only if already has data
+        onRefresh = { viewModel.loadPostsForCategory() }
+    )
+    var showDislikeDialog by remember { mutableStateOf(false) }
+    var postToDislike by remember { mutableStateOf<String?>(null) }
+
+
+    if (showDislikeDialog && postToDislike != null) {
+        AlertDialog(
+            onDismissRequest = {
+                showDislikeDialog = false
+                postToDislike = null
+            },
+            title = { Text("Batalkan Like?", style = MaterialTheme.typography.titleLarge, fontWeight = FontWeight.Bold) },
+            text = { Text("Apakah Anda yakin ingin membatalkan like pada postingan ini?", style = MaterialTheme.typography.bodyMedium) },
+            confirmButton = {
+                Button(
+                    onClick = {
+                        postToDislike?.let { postId -> viewModel.performDislike(postId) }
+                        showDislikeDialog = false
+                        postToDislike = null
+                    },
+                    colors = ButtonDefaults.buttonColors(containerColor = MaterialTheme.colorScheme.error)
+                ) { Text("Ya, Batalkan Like") }
+            },
+            dismissButton = {
+                TextButton(onClick = { showDislikeDialog = false; postToDislike = null }) { Text("Batal") }
+            },
+            icon = { Icon(Icons.Default.HeartBroken, contentDescription = null, tint = MaterialTheme.colorScheme.error, modifier = Modifier.size(32.dp)) }
+        )
+    }
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text(uiState.categoryName.ifEmpty { "Post Kategori" }, fontWeight = FontWeight.Bold) },
+                navigationIcon = {
+                    IconButton(onClick = onNavigateBack) {
+                        Icon(Icons.Default.ArrowBack, contentDescription = "Kembali")
+                    }
+                },
+                colors = TopAppBarDefaults.topAppBarColors(
+                    containerColor = MaterialTheme.colorScheme.surface,
+                    titleContentColor = MaterialTheme.colorScheme.onSurface
+                )
+            )
+        }
+    ) { paddingValues ->
+        Box(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(paddingValues)
+                .background(MaterialTheme.colorScheme.background)
+                .pullRefresh(pullRefreshState)
+        ) {
+            when {
+                uiState.isLoading && uiState.posts.isEmpty() -> LoadingIndicator(message = "Memuat post...")
+                uiState.error != null -> ErrorMessage(
+                    message = uiState.error!!,
+                    onRetry = { viewModel.loadPostsForCategory() },
+                    modifier = Modifier.padding(16.dp)
+                )
+                uiState.posts.isEmpty() -> {
+                    Box(modifier = Modifier.fillMaxSize().padding(16.dp), contentAlignment = Alignment.Center) {
+                        Column(horizontalAlignment = Alignment.CenterHorizontally) {
+                            Text("Belum ada postingan di kategori ini.", style = MaterialTheme.typography.bodyLarge)
+                            Spacer(Modifier.height(8.dp))
+                            Text("Tarik ke bawah untuk refresh.", style = MaterialTheme.typography.bodySmall)
+                        }
+                    }
+                }
+                else -> {
+                    LazyColumn(
+                        contentPadding = PaddingValues(16.dp),
+                        verticalArrangement = Arrangement.spacedBy(16.dp),
+                        modifier = Modifier.fillMaxSize()
+                    ) {
+                        items(uiState.posts, key = { it.id }) { post ->
+                            PostCard(
+                                post = post,
+                                onClick = { onNavigateToPostDetail(post.id) },
+                                onLikeClick = { postId ->
+                                    viewModel.togglePostLike(postId) {
+                                        postToDislike = postId
+                                        showDislikeDialog = true
+                                    }
+                                },
+                                isLikeLoading = uiState.likingPostIds.contains(post.id)
+                            )
+                        }
+                    }
+                }
+            }
+            PullRefreshIndicator(
+                refreshing = uiState.isLoading && uiState.posts.isNotEmpty(),
+                state = pullRefreshState,
+                modifier = Modifier.align(Alignment.TopCenter),
+                backgroundColor = MaterialTheme.colorScheme.surface,
+                contentColor = MaterialTheme.colorScheme.primary
+            )
+        }
+    }
+}

--- a/app/src/main/java/com/virtualsblog/project/presentation/ui/screen/category/posts/CategoryPostsUiState.kt
+++ b/app/src/main/java/com/virtualsblog/project/presentation/ui/screen/category/posts/CategoryPostsUiState.kt
@@ -1,0 +1,11 @@
+package com.virtualsblog.project.presentation.ui.screen.category.posts
+
+import com.virtualsblog.project.domain.model.Post
+
+data class CategoryPostsUiState(
+    val isLoading: Boolean = false,
+    val posts: List<Post> = emptyList(),
+    val categoryName: String = "",
+    val error: String? = null,
+    val likingPostIds: Set<String> = emptySet()
+)

--- a/app/src/main/java/com/virtualsblog/project/presentation/ui/screen/category/posts/CategoryPostsViewModel.kt
+++ b/app/src/main/java/com/virtualsblog/project/presentation/ui/screen/category/posts/CategoryPostsViewModel.kt
@@ -1,0 +1,119 @@
+package com.virtualsblog.project.presentation.ui.screen.category.posts
+
+import androidx.lifecycle.SavedStateHandle
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.virtualsblog.project.domain.usecase.blog.GetPostsByCategoryIdUseCase
+import com.virtualsblog.project.domain.usecase.blog.ToggleLikeUseCase
+import com.virtualsblog.project.presentation.ui.navigation.BlogDestinations
+import com.virtualsblog.project.util.Resource
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+@HiltViewModel
+class CategoryPostsViewModel @Inject constructor(
+    private val getPostsByCategoryIdUseCase: GetPostsByCategoryIdUseCase,
+    private val toggleLikeUseCase: ToggleLikeUseCase,
+    savedStateHandle: SavedStateHandle
+) : ViewModel() {
+
+    private val categoryId: String = savedStateHandle.get<String>(BlogDestinations.Args.CATEGORY_ID) ?: ""
+    private val categoryNameArg: String = savedStateHandle.get<String>(BlogDestinations.Args.CATEGORY_NAME) ?: "Kategori"
+
+    private val _uiState = MutableStateFlow(CategoryPostsUiState(categoryName = categoryNameArg))
+    val uiState: StateFlow<CategoryPostsUiState> = _uiState.asStateFlow()
+
+    init {
+        if (categoryId.isNotBlank()) {
+            loadPostsForCategory(categoryId)
+        } else {
+            _uiState.value = _uiState.value.copy(error = "ID Kategori tidak valid.")
+        }
+    }
+
+    fun loadPostsForCategory(catId: String = categoryId) {
+        viewModelScope.launch {
+            _uiState.value = _uiState.value.copy(isLoading = true, error = null)
+            getPostsByCategoryIdUseCase(catId).collect { result ->
+                when (result) {
+                    is Resource.Success -> {
+                        _uiState.value = _uiState.value.copy(
+                            isLoading = false,
+                            posts = result.data ?: emptyList(),
+                            error = null
+                        )
+                    }
+                    is Resource.Error -> {
+                        _uiState.value = _uiState.value.copy(
+                            isLoading = false,
+                            error = result.message ?: "Gagal memuat post untuk kategori ini."
+                        )
+                    }
+                    is Resource.Loading -> {
+                        _uiState.value = _uiState.value.copy(isLoading = true)
+                    }
+                }
+            }
+        }
+    }
+
+    fun togglePostLike(postId: String, onConfirmDislike: () -> Unit) {
+        val currentPosts = _uiState.value.posts
+        val postIndex = currentPosts.indexOfFirst { it.id == postId }
+        if (postIndex == -1) return
+
+        val currentPost = currentPosts[postIndex]
+        if (currentPost.isLiked) {
+            onConfirmDislike()
+            return
+        }
+        performLikeToggle(postId)
+    }
+
+    fun performDislike(postId: String) {
+        performLikeToggle(postId)
+    }
+
+    private fun performLikeToggle(postId: String) {
+        viewModelScope.launch {
+            _uiState.value = _uiState.value.copy(likingPostIds = _uiState.value.likingPostIds + postId)
+            toggleLikeUseCase(postId).collect { resource ->
+                when (resource) {
+                    is Resource.Success -> {
+                        val isLiked = resource.data?.first ?: false
+                        _uiState.value = _uiState.value.copy(
+                            posts = _uiState.value.posts.map {
+                                if (it.id == postId) {
+                                    it.copy(
+                                        isLiked = isLiked,
+                                        likes = if (isLiked) it.likes + 1 else maxOf(0, it.likes -1)
+                                    )
+                                } else it
+                            },
+                            likingPostIds = _uiState.value.likingPostIds - postId
+                        )
+                        // Optionally, reload all posts for the category to get the most accurate like count from server
+                        // loadPostsForCategory(categoryId)
+                    }
+                    is Resource.Error -> {
+                        _uiState.value = _uiState.value.copy(
+                            error = resource.message ?: "Gagal mengubah status like.",
+                            likingPostIds = _uiState.value.likingPostIds - postId
+                        )
+                    }
+                    is Resource.Loading -> {
+                        // Handled by adding to likingPostIds
+                    }
+                }
+            }
+        }
+    }
+
+    fun clearError() {
+        _uiState.value = _uiState.value.copy(error = null)
+    }
+}

--- a/app/src/main/java/com/virtualsblog/project/presentation/ui/screen/home/HomeScreen.kt
+++ b/app/src/main/java/com/virtualsblog/project/presentation/ui/screen/home/HomeScreen.kt
@@ -1,4 +1,4 @@
-// HomeScreen.kt - Updated with Dislike Confirmation
+// HomeScreen.kt - Updated with Dislike Confirmation & Categories Navigation
 package com.virtualsblog.project.presentation.ui.screen.home
 
 import androidx.compose.animation.*
@@ -11,6 +11,7 @@ import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.*
+import androidx.compose.material.icons.outlined.Category // *** NEW IMPORT FOR CATEGORY ICON ***
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
@@ -38,6 +39,8 @@ fun HomeScreen(
     onNavigateToPostDetail: (String) -> Unit,
     onNavigateToLogin: () -> Unit,
     onNavigateToAllPosts: () -> Unit,
+    onNavigateToCategories: () -> Unit, // *** NEW PARAMETER ***
+    onNavigateToSearch: () -> Unit,
     viewModel: HomeViewModel = hiltViewModel()
 ) {
     val uiState by viewModel.uiState.collectAsState()
@@ -135,7 +138,8 @@ fun HomeScreen(
                 username = uiState.username,
                 userImageUrl = uiState.userImageUrl,
                 onProfileClick = onNavigateToProfile,
-                onSearchClick = { /* TODO: Implementasi pencarian */ }
+                onSearchClick = onNavigateToSearch,
+                onCategoriesClick = onNavigateToCategories // *** PASS NAVIGATION HERE ***
             )
         },
         floatingActionButton = {
@@ -179,15 +183,16 @@ fun HomeScreen(
                         item {
                             EnhancedStatisticsCard(
                                 totalPosts = uiState.totalPostsCount,
-                                totalUsers = 42,
-                                onViewAllPosts = onNavigateToAllPosts
+                                totalUsers = 42, // Placeholder
+                                onViewAllPosts = onNavigateToAllPosts,
+                                onViewCategories = onNavigateToCategories // *** ADDED CATEGORIES NAVIGATION ***
                             )
                         }
 
                         // Enhanced Section Header
                         item {
                             EnhancedSectionHeader(
-                                title = "📝 Postingan Terbaru",
+                                title = "✨ Postingan Terbaru",
                                 subtitle = "Tarik ke bawah untuk refresh",
                                 onViewAll = onNavigateToAllPosts
                             )
@@ -236,13 +241,13 @@ fun HomeScreen(
     }
 }
 
-// Enhanced components tetap sama seperti sebelumnya...
 @Composable
 private fun EnhancedTopAppBar(
     username: String,
     userImageUrl: String?,
     onProfileClick: () -> Unit,
-    onSearchClick: () -> Unit
+    onSearchClick: () -> Unit,
+    onCategoriesClick: () -> Unit // *** NEW PARAMETER ***
 ) {
     Surface(
         modifier = Modifier.fillMaxWidth(),
@@ -276,15 +281,29 @@ private fun EnhancedTopAppBar(
                 horizontalArrangement = Arrangement.spacedBy(8.dp),
                 verticalAlignment = Alignment.CenterVertically
             ) {
-                FilledIconButton(
-                    onClick = onSearchClick,
-                    colors = IconButtonDefaults.filledIconButtonColors(
-                        containerColor = MaterialTheme.colorScheme.primary,
-                        contentColor = MaterialTheme.colorScheme.onPrimary
+                // *** ADDED CATEGORIES BUTTON ***
+                IconButton(
+                    onClick = onCategoriesClick,
+                    colors = IconButtonDefaults.iconButtonColors(
+                        containerColor = Color.Transparent, // Or primary if preferred
+                        contentColor = MaterialTheme.colorScheme.primary // Or onPrimary
                     )
                 ) {
                     Icon(
-                        imageVector = Icons.Default.Search,
+                        imageVector = Icons.Outlined.Category,
+                        contentDescription = "Kategori"
+                    )
+                }
+
+                IconButton( // Changed from FilledIconButton to IconButton for consistency
+                    onClick = onSearchClick, // Uses the passed lambda
+                    colors = IconButtonDefaults.iconButtonColors(
+                        containerColor = Color.Transparent,
+                        contentColor = MaterialTheme.colorScheme.primary
+                    )
+                ) {
+                    Icon(
+                        imageVector = Icons.Filled.Search, // Using Filled.Search icon
                         contentDescription = "Cari"
                     )
                 }
@@ -324,7 +343,7 @@ private fun EnhancedFloatingActionButton(
     }
 }
 
-// Tambahan component lainnya tetap sama...
+// Tambahan component lainnya tetap sama seperti sebelumnya...
 @Composable
 private fun EnhancedWelcomeHeader(username: String) {
     Card(
@@ -372,7 +391,8 @@ private fun EnhancedWelcomeHeader(username: String) {
 private fun EnhancedStatisticsCard(
     totalPosts: Int,
     totalUsers: Int,
-    onViewAllPosts: () -> Unit
+    onViewAllPosts: () -> Unit,
+    onViewCategories: () -> Unit // *** NEW PARAMETER ***
 ) {
     Card(
         modifier = Modifier.fillMaxWidth(),
@@ -396,8 +416,15 @@ private fun EnhancedStatisticsCard(
                     fontWeight = FontWeight.Bold
                 )
 
-                TextButton(onClick = onViewAllPosts) {
-                    Text("Lihat Semua")
+                // *** UPDATED TO INCLUDE CATEGORIES BUTTON ***
+                Row {
+                    TextButton(onClick = onViewCategories) {
+                        Text("Kategori")
+                    }
+                    Spacer(Modifier.width(8.dp))
+                    TextButton(onClick = onViewAllPosts) {
+                        Text("Semua Post")
+                    }
                 }
             }
 
@@ -423,7 +450,7 @@ private fun EnhancedStatisticsCard(
                 EnhancedStatItem(
                     icon = Icons.Default.People,
                     title = "Pengguna Aktif",
-                    value = formatCount(totalUsers),
+                    value = formatCount(totalUsers), // Placeholder, replace with actual data if available
                     color = MaterialTheme.colorScheme.secondary,
                     modifier = Modifier.weight(1f)
                 )

--- a/app/src/main/java/com/virtualsblog/project/presentation/ui/screen/search/SearchScreen.kt
+++ b/app/src/main/java/com/virtualsblog/project/presentation/ui/screen/search/SearchScreen.kt
@@ -1,0 +1,220 @@
+package com.virtualsblog.project.presentation.ui.screen.search
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.text.KeyboardActions
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.*
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalFocusManager
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.input.ImeAction
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import com.virtualsblog.project.domain.model.Category
+import com.virtualsblog.project.domain.model.Post
+import com.virtualsblog.project.domain.model.User
+import com.virtualsblog.project.presentation.ui.component.ErrorMessage
+import com.virtualsblog.project.presentation.ui.component.LoadingIndicator
+import com.virtualsblog.project.presentation.ui.component.PostCard
+import com.virtualsblog.project.presentation.ui.component.UserAvatar
+import com.virtualsblog.project.util.Constants
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun SearchScreen(
+    onNavigateBack: () -> Unit,
+    onNavigateToPostDetail: (String) -> Unit,
+    onNavigateToUserProfile: (String) -> Unit, // Assuming user ID for navigation
+    onNavigateToCategoryPosts: (categoryId: String, categoryName: String) -> Unit,
+    viewModel: SearchViewModel = hiltViewModel()
+) {
+    val uiState by viewModel.uiState.collectAsState()
+    val focusManager = LocalFocusManager.current
+    val focusRequester = remember { FocusRequester() }
+
+    LaunchedEffect(Unit) {
+        focusRequester.requestFocus()
+    }
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = {
+                    OutlinedTextField(
+                        value = uiState.searchQuery,
+                        onValueChange = { viewModel.onSearchQueryChanged(it) },
+                        placeholder = { Text(Constants.SEARCH_HINT) },
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(end = 16.dp) // Give space for clear button if any
+                            .focusRequester(focusRequester),
+                        singleLine = true,
+                        keyboardOptions = KeyboardOptions.Default.copy(imeAction = ImeAction.Search),
+                        keyboardActions = KeyboardActions(onSearch = {
+                            focusManager.clearFocus()
+                            viewModel.performSearch()
+                        }),
+                        trailingIcon = {
+                            if (uiState.searchQuery.isNotEmpty()) {
+                                IconButton(onClick = { viewModel.onSearchQueryChanged("") }) {
+                                    Icon(Icons.Default.Clear, contentDescription = "Clear search")
+                                }
+                            }
+                        },
+                        colors = OutlinedTextFieldDefaults.colors(
+                            focusedBorderColor = Color.Transparent,
+                            unfocusedBorderColor = Color.Transparent,
+                            cursorColor = MaterialTheme.colorScheme.primary
+                        )
+                    )
+                },
+                navigationIcon = {
+                    IconButton(onClick = onNavigateBack) {
+                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Kembali")
+                    }
+                },
+                colors = TopAppBarDefaults.topAppBarColors(
+                    containerColor = MaterialTheme.colorScheme.surface
+                )
+            )
+        }
+    ) { paddingValues ->
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(paddingValues)
+                .background(MaterialTheme.colorScheme.background)
+        ) {
+            if (uiState.isLoading) {
+                LoadingIndicator(message = "Mencari...")
+            } else if (uiState.error != null) {
+                ErrorMessage(
+                    message = uiState.error!!,
+                    onRetry = { viewModel.performSearch() },
+                    modifier = Modifier.padding(16.dp)
+                )
+            } else if (uiState.isInitialState) {
+                Box(modifier = Modifier.fillMaxSize().padding(16.dp), contentAlignment = Alignment.Center) {
+                    Column(horizontalAlignment = Alignment.CenterHorizontally) {
+                        Icon(Icons.Default.Search, contentDescription = null, modifier = Modifier.size(64.dp), tint = MaterialTheme.colorScheme.onSurfaceVariant)
+                        Spacer(Modifier.height(16.dp))
+                        Text(
+                            "Cari Postingan, Pengguna, atau Kategori",
+                            style = MaterialTheme.typography.titleMedium,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                            textAlign = TextAlign.Center
+                        )
+                    }
+                }
+            } else if (uiState.searchResults == null ||
+                (uiState.searchResults!!.users.isEmpty() && uiState.searchResults!!.categories.isEmpty() && uiState.searchResults!!.posts.isEmpty())
+            ) {
+                Box(modifier = Modifier.fillMaxSize().padding(16.dp), contentAlignment = Alignment.Center) {
+                    Column(horizontalAlignment = Alignment.CenterHorizontally) {
+                        Icon(Icons.Default.SentimentDissatisfied, contentDescription = null, modifier = Modifier.size(64.dp), tint = MaterialTheme.colorScheme.onSurfaceVariant)
+                        Spacer(Modifier.height(16.dp))
+                        Text(
+                            "Tidak ada hasil untuk \"${uiState.searchQuery}\"",
+                            style = MaterialTheme.typography.titleMedium,
+                            textAlign = TextAlign.Center,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant
+                        )
+                    }
+                }
+            } else {
+                LazyColumn(
+                    contentPadding = PaddingValues(16.dp),
+                    verticalArrangement = Arrangement.spacedBy(16.dp)
+                ) {
+                    uiState.searchResults?.let { results ->
+                        if (results.users.isNotEmpty()) {
+                            item { SearchSectionHeader("Pengguna") }
+                            items(results.users, key = { it.id }) { user ->
+                                UserResultItem(user = user, onClick = { onNavigateToUserProfile(user.id) })
+                            }
+                        }
+                        if (results.categories.isNotEmpty()) {
+                            item { SearchSectionHeader("Kategori") }
+                            items(results.categories, key = { it.id }) { category ->
+                                CategoryResultItem(category = category, onClick = { onNavigateToCategoryPosts(category.id, category.name) })
+                            }
+                        }
+                        if (results.posts.isNotEmpty()) {
+                            item { SearchSectionHeader("Postingan") }
+                            items(results.posts, key = { it.id }) { post ->
+                                PostCard(post = post, onClick = { onNavigateToPostDetail(post.id) })
+                                // Like functionality can be added here if needed, similar to HomeScreen
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun SearchSectionHeader(title: String) {
+    Text(
+        text = title,
+        style = MaterialTheme.typography.titleLarge,
+        fontWeight = FontWeight.Bold,
+        modifier = Modifier.padding(bottom = 8.dp, top = 8.dp)
+    )
+}
+
+@Composable
+private fun UserResultItem(user: User, onClick: () -> Unit) {
+    Card(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clickable(onClick = onClick),
+        shape = MaterialTheme.shapes.medium,
+        colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surfaceVariant)
+    ) {
+        Row(
+            modifier = Modifier.padding(16.dp),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            UserAvatar(userName = user.fullname, imageUrl = user.image, size = 48.dp)
+            Spacer(modifier = Modifier.width(16.dp))
+            Column {
+                Text(user.fullname, style = MaterialTheme.typography.titleMedium, fontWeight = FontWeight.SemiBold)
+                Text("@${user.username}", style = MaterialTheme.typography.bodyMedium, color = MaterialTheme.colorScheme.onSurfaceVariant)
+            }
+        }
+    }
+}
+
+@Composable
+private fun CategoryResultItem(category: Category, onClick: () -> Unit) {
+    Card(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clickable(onClick = onClick),
+        shape = MaterialTheme.shapes.medium,
+        colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.secondaryContainer.copy(alpha = 0.7f))
+    ) {
+        Row(
+            modifier = Modifier.padding(16.dp),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Icon(Icons.Default.Category, contentDescription = "Kategori", tint = MaterialTheme.colorScheme.onSecondaryContainer)
+            Spacer(modifier = Modifier.width(16.dp))
+            Text(category.name, style = MaterialTheme.typography.titleMedium, fontWeight = FontWeight.SemiBold, color = MaterialTheme.colorScheme.onSecondaryContainer)
+        }
+    }
+}

--- a/app/src/main/java/com/virtualsblog/project/presentation/ui/screen/search/SearchUiState.kt
+++ b/app/src/main/java/com/virtualsblog/project/presentation/ui/screen/search/SearchUiState.kt
@@ -1,0 +1,11 @@
+package com.virtualsblog.project.presentation.ui.screen.search
+
+import com.virtualsblog.project.domain.model.SearchData
+
+data class SearchUiState(
+    val isLoading: Boolean = false,
+    val searchQuery: String = "",
+    val searchResults: SearchData? = null,
+    val error: String? = null,
+    val isInitialState: Boolean = true // To show a prompt before first search
+)

--- a/app/src/main/java/com/virtualsblog/project/presentation/ui/screen/search/SearchViewModel.kt
+++ b/app/src/main/java/com/virtualsblog/project/presentation/ui/screen/search/SearchViewModel.kt
@@ -1,0 +1,84 @@
+package com.virtualsblog.project.presentation.ui.screen.search
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.virtualsblog.project.domain.usecase.blog.SearchUseCase
+import com.virtualsblog.project.util.Resource
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+@HiltViewModel
+class SearchViewModel @Inject constructor(
+    private val searchUseCase: SearchUseCase
+) : ViewModel() {
+
+    private val _uiState = MutableStateFlow(SearchUiState())
+    val uiState: StateFlow<SearchUiState> = _uiState.asStateFlow()
+
+    private var searchJob: Job? = null
+
+    fun onSearchQueryChanged(query: String) {
+        _uiState.value = _uiState.value.copy(searchQuery = query)
+        searchJob?.cancel() // Cancel previous job if user is still typing
+        if (query.length >= 2) { // Perform search if query is 2 or more characters, or adjust as needed
+            searchJob = viewModelScope.launch {
+                delay(500) // Debounce: wait for 500ms after user stops typing
+                performSearch(query)
+            }
+        } else if (query.isEmpty()) {
+            // Clear results if query is empty, and reset to initial state
+            _uiState.value = _uiState.value.copy(searchResults = null, error = null, isInitialState = true)
+        }
+    }
+
+    fun performSearch(query: String = _uiState.value.searchQuery) {
+        if (query.isBlank()) {
+            _uiState.value = _uiState.value.copy(
+                error = "Keyword pencarian tidak boleh kosong.",
+                searchResults = null,
+                isInitialState = true // Back to initial state if query is blanked after a search
+            )
+            return
+        }
+        searchJob?.cancel() // Cancel any existing debounced job
+        viewModelScope.launch {
+            _uiState.value = _uiState.value.copy(isLoading = true, error = null, isInitialState = false)
+            searchUseCase(query).collect { result ->
+                when (result) {
+                    is Resource.Success -> {
+                        _uiState.value = _uiState.value.copy(
+                            isLoading = false,
+                            searchResults = result.data,
+                            error = null
+                        )
+                    }
+                    is Resource.Error -> {
+                        _uiState.value = _uiState.value.copy(
+                            isLoading = false,
+                            error = result.message ?: "Gagal melakukan pencarian.",
+                            searchResults = null // Clear previous results on error
+                        )
+                    }
+                    is Resource.Loading -> {
+                        _uiState.value = _uiState.value.copy(isLoading = true, error = null, isInitialState = false)
+                    }
+                }
+            }
+        }
+    }
+
+    fun clearError() {
+        _uiState.value = _uiState.value.copy(error = null)
+    }
+
+    fun clearSearch() {
+        _uiState.value = SearchUiState() // Reset to initial state
+        searchJob?.cancel()
+    }
+}


### PR DESCRIPTION
This commit introduces two major features:
1. Category Browse:
   - Users can now view a list of all post categories.
   - Users can select a category to view posts belonging to that specific category.
   - Includes new screens (CategoriesScreen, CategoryPostsScreen) and corresponding ViewModels (CategoriesViewModel, CategoryPostsViewModel).
   - Added GetPostsByCategoryIdUseCase and updated data layer (API, Repository).
   - Navigation updated to support category flows.
   - Note: Backend for GET /categories/{id} currently does not filter correctly.

2. Global Search:
   - Users can now search for posts, users, and categories using a keyword.
   - Includes new SearchScreen and SearchViewModel with debounce functionality.
   - Added SearchUseCase and relevant data/domain models (SearchData, SearchResponseData).
   - Updated data layer (API, Repository) for the search endpoint.
   - Navigation updated to include the search flow from HomeScreen.