### PR TITLE
feat: Implement Author Posts Screen and update Search navigation

### DIFF
--- a/app/src/main/java/com/virtualsblog/project/data/remote/api/BlogApi.kt
+++ b/app/src/main/java/com/virtualsblog/project/data/remote/api/BlogApi.kt
@@ -33,12 +33,18 @@ interface BlogApi {
         @Header(Constants.HEADER_AUTHORIZATION) authorization: String
     ): Response<PostsApiResponse>
 
-    // *** NEW SEARCH FUNCTION ***
     @GET("search")
     suspend fun search(
         @Query("keyword") keyword: String,
         @Header(Constants.HEADER_AUTHORIZATION) authorization: String
-    ): Response<ApiResponse<SearchResponseData>> //
+    ): Response<ApiResponse<SearchResponseData>>
+
+    // *** Endpoint for getting posts by author ID (as per API documentation) ***
+    @GET("authors/{id}")
+    suspend fun getPostsByAuthorId(
+        @Path("id") authorId: String,
+        @Header(Constants.HEADER_AUTHORIZATION) authorization: String
+    ): Response<PostsApiResponse>
 
     @Multipart
     @POST("posts")

--- a/app/src/main/java/com/virtualsblog/project/di/UseCaseModule.kt
+++ b/app/src/main/java/com/virtualsblog/project/di/UseCaseModule.kt
@@ -13,12 +13,14 @@ import com.virtualsblog.project.domain.usecase.blog.GetPostsForHomeUseCase
 import com.virtualsblog.project.domain.usecase.blog.GetTotalPostsCountUseCase
 import com.virtualsblog.project.domain.usecase.blog.GetPostByIdUseCase
 import com.virtualsblog.project.domain.usecase.blog.ToggleLikeUseCase
-import com.virtualsblog.project.domain.usecase.blog.CreatePostUseCase // Make sure this is imported
-import com.virtualsblog.project.domain.usecase.blog.UpdatePostUseCase // New
-import com.virtualsblog.project.domain.usecase.blog.DeletePostUseCase // New
-import com.virtualsblog.project.domain.usecase.blog.GetCategoriesUseCase // Make sure this is imported
-import com.virtualsblog.project.domain.usecase.blog.GetPostsByCategoryIdUseCase // *** NEW IMPORT ***
+import com.virtualsblog.project.domain.usecase.blog.CreatePostUseCase
+import com.virtualsblog.project.domain.usecase.blog.UpdatePostUseCase
+import com.virtualsblog.project.domain.usecase.blog.DeletePostUseCase
+import com.virtualsblog.project.domain.usecase.blog.GetCategoriesUseCase
+import com.virtualsblog.project.domain.usecase.blog.GetPostsByCategoryIdUseCase
 import com.virtualsblog.project.domain.usecase.blog.SearchUseCase
+// *** NEW IMPORT FOR GetPostsByAuthorIdUseCase ***
+import com.virtualsblog.project.domain.usecase.blog.GetPostsByAuthorIdUseCase
 import com.virtualsblog.project.domain.usecase.comment.CreateCommentUseCase
 import com.virtualsblog.project.domain.usecase.comment.DeleteCommentUseCase
 
@@ -99,22 +101,25 @@ object UseCaseModule {
 
     @Provides
     @Singleton
-    fun provideCreatePostUseCase(repository: BlogRepository): CreatePostUseCase = CreatePostUseCase(repository) // Ensure this exists
+    fun provideCreatePostUseCase(repository: BlogRepository): CreatePostUseCase = CreatePostUseCase(repository)
 
     @Provides
     @Singleton
-    fun provideGetCategoriesUseCase(repository: BlogRepository): GetCategoriesUseCase = GetCategoriesUseCase(repository) // Ensure this exists
+    fun provideGetCategoriesUseCase(repository: BlogRepository): GetCategoriesUseCase = GetCategoriesUseCase(repository)
 
-    // *** NEW USE CASE PROVIDER ***
     @Provides
     @Singleton
     fun provideGetPostsByCategoryIdUseCase(repository: BlogRepository): GetPostsByCategoryIdUseCase = GetPostsByCategoryIdUseCase(repository)
+
+    // *** NEW PROVIDER FOR GetPostsByAuthorIdUseCase ***
+    @Provides
+    @Singleton
+    fun provideGetPostsByAuthorIdUseCase(repository: BlogRepository): GetPostsByAuthorIdUseCase = GetPostsByAuthorIdUseCase(repository)
 
     @Provides
     @Singleton
     fun provideSearchUseCase(repository: BlogRepository): SearchUseCase = SearchUseCase(repository)
 
-    // New Blog UseCases for Edit and Delete
     @Provides
     @Singleton
     fun provideUpdatePostUseCase(repository: BlogRepository): UpdatePostUseCase = UpdatePostUseCase(repository)

--- a/app/src/main/java/com/virtualsblog/project/domain/repository/BlogRepository.kt
+++ b/app/src/main/java/com/virtualsblog/project/domain/repository/BlogRepository.kt
@@ -15,9 +15,10 @@ interface BlogRepository {
     suspend fun getTotalPostsCount(): Flow<Resource<Int>>
     suspend fun getPostById(postId: String): Flow<Resource<Post>>
     suspend fun getCategories(): Flow<Resource<List<Category>>>
-
-
     suspend fun getPostsByCategoryId(categoryId: String): Flow<Resource<List<Post>>>
+
+    // *** NEW FUNCTION TO GET POSTS BY AUTHOR ID ***
+    suspend fun getPostsByAuthorId(authorId: String): Flow<Resource<List<Post>>>
 
     suspend fun search(keyword: String): Flow<Resource<SearchData>>
 

--- a/app/src/main/java/com/virtualsblog/project/domain/usecase/blog/GetPostsByAuthorIdUseCase.kt
+++ b/app/src/main/java/com/virtualsblog/project/domain/usecase/blog/GetPostsByAuthorIdUseCase.kt
@@ -1,0 +1,18 @@
+package com.virtualsblog.project.domain.usecase.blog
+
+import com.virtualsblog.project.domain.model.Post
+import com.virtualsblog.project.domain.repository.BlogRepository
+import com.virtualsblog.project.util.Resource
+import kotlinx.coroutines.flow.Flow
+import javax.inject.Inject
+
+class GetPostsByAuthorIdUseCase @Inject constructor(
+    private val repository: BlogRepository
+) {
+    suspend operator fun invoke(authorId: String): Flow<Resource<List<Post>>> {
+        if (authorId.isBlank()) {
+            return kotlinx.coroutines.flow.flow { emit(Resource.Error("ID Author tidak boleh kosong.")) }
+        }
+        return repository.getPostsByAuthorId(authorId)
+    }
+}

--- a/app/src/main/java/com/virtualsblog/project/presentation/ui/navigation/BlogDestinations.kt
+++ b/app/src/main/java/com/virtualsblog/project/presentation/ui/navigation/BlogDestinations.kt
@@ -1,5 +1,8 @@
 package com.virtualsblog.project.presentation.ui.navigation
 
+import java.net.URLEncoder
+import java.nio.charset.StandardCharsets
+
 /**
  * Destinations for navigation in the application
  */
@@ -12,18 +15,17 @@ object BlogDestinations {
     const val VERIFY_OTP_ROUTE = "verify_otp"
     const val RESET_PASSWORD_ROUTE = "reset_password"
     const val HOME_ROUTE = "home"
-    const val PROFILE_ROUTE = "profile"
+    const val PROFILE_ROUTE = "profile" // This is for the current user's profile
     const val CHANGE_PASSWORD_ROUTE = "change_password"
     const val CREATE_POST_ROUTE = "create_post"
     const val POST_LIST_ROUTE = "post_list"
     const val POST_DETAIL_ROUTE = "post_detail"
     const val EDIT_POST_ROUTE = "edit_post"
     const val TERMS_AND_CONDITIONS_ROUTE = "terms_and_conditions"
-    // *** NEW ROUTES ***
     const val CATEGORIES_ROUTE = "categories"
     const val CATEGORY_POSTS_ROUTE = "category_posts"
-    const val SEARCH_ROUTE = "search" // *** NEW ROUTE ***
-
+    const val SEARCH_ROUTE = "search"
+    const val AUTHOR_POSTS_ROUTE = "author_posts" // *** NEW ROUTE ***
 
 
     // Routes with parameters
@@ -31,8 +33,9 @@ object BlogDestinations {
     const val RESET_PASSWORD_WITH_PARAMS = "$RESET_PASSWORD_ROUTE/{${Args.TOKEN_ID}}/{${Args.OTP}}"
     const val POST_DETAIL_WITH_ID = "$POST_DETAIL_ROUTE/{${Args.POST_ID}}"
     const val EDIT_POST_WITH_ID = "$EDIT_POST_ROUTE/{${Args.POST_ID}}"
-    // *** NEW ROUTE WITH PARAMETERS ***
     const val CATEGORY_POSTS_WITH_ID_AND_NAME = "$CATEGORY_POSTS_ROUTE/{${Args.CATEGORY_ID}}/{${Args.CATEGORY_NAME}}"
+    // *** NEW ROUTE WITH PARAMETERS FOR AUTHOR POSTS ***
+    const val AUTHOR_POSTS_WITH_ID_AND_NAME = "$AUTHOR_POSTS_ROUTE/{${Args.AUTHOR_ID}}/{${Args.AUTHOR_NAME}}"
 
 
     // Helper functions to create routes with parameters
@@ -40,8 +43,15 @@ object BlogDestinations {
     fun resetPasswordRoute(tokenId: String, otp: String) = "$RESET_PASSWORD_ROUTE/$tokenId/$otp"
     fun postDetailRoute(postId: String) = "$POST_DETAIL_ROUTE/$postId"
     fun editPostRoute(postId: String) = "$EDIT_POST_ROUTE/$postId"
-    // *** NEW HELPER FUNCTION ***
-    fun categoryPostsRoute(categoryId: String, categoryName: String) = "$CATEGORY_POSTS_ROUTE/$categoryId/$categoryName"
+    fun categoryPostsRoute(categoryId: String, categoryName: String): String {
+        val encodedCategoryName = URLEncoder.encode(categoryName, StandardCharsets.UTF_8.toString())
+        return "$CATEGORY_POSTS_ROUTE/$categoryId/$encodedCategoryName"
+    }
+    // *** NEW HELPER FUNCTION FOR AUTHOR POSTS ***
+    fun authorPostsRoute(authorId: String, authorName: String): String {
+        val encodedAuthorName = URLEncoder.encode(authorName, StandardCharsets.UTF_8.toString())
+        return "$AUTHOR_POSTS_ROUTE/$authorId/$encodedAuthorName"
+    }
 
 
     // Auth-specific nested routes
@@ -60,8 +70,10 @@ object BlogDestinations {
         const val TOKEN_ID = "tokenId"
         const val OTP = "otp"
         const val POST_ID = "postId"
-        // *** NEW ARGS ***
         const val CATEGORY_ID = "categoryId"
         const val CATEGORY_NAME = "categoryName"
+        // *** NEW ARGS FOR AUTHOR POSTS ***
+        const val AUTHOR_ID = "authorId"
+        const val AUTHOR_NAME = "authorName"
     }
 }

--- a/app/src/main/java/com/virtualsblog/project/presentation/ui/navigation/BlogNavGraph.kt
+++ b/app/src/main/java/com/virtualsblog/project/presentation/ui/navigation/BlogNavGraph.kt
@@ -2,28 +2,30 @@ package com.virtualsblog.project.presentation.ui.navigation
 
 import androidx.compose.runtime.Composable
 import androidx.navigation.NavHostController
+import androidx.navigation.NavType
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.navArgument
-import androidx.navigation.NavType
 import com.virtualsblog.project.presentation.MainViewModel
-import com.virtualsblog.project.presentation.ui.screen.auth.login.LoginScreen
-import com.virtualsblog.project.presentation.ui.screen.auth.register.RegisterScreen
-import com.virtualsblog.project.presentation.ui.screen.auth.profile.ProfileScreen
+import com.virtualsblog.project.presentation.ui.screen.auth.changepassword.ChangePasswordScreen
 import com.virtualsblog.project.presentation.ui.screen.auth.forgotpassword.ForgotPasswordScreen
-import com.virtualsblog.project.presentation.ui.screen.auth.verifyotp.VerifyOtpScreen
+import com.virtualsblog.project.presentation.ui.screen.auth.login.LoginScreen
+import com.virtualsblog.project.presentation.ui.screen.auth.profile.ProfileScreen
+import com.virtualsblog.project.presentation.ui.screen.auth.register.RegisterScreen
 import com.virtualsblog.project.presentation.ui.screen.auth.resetpassword.ResetPasswordScreen
 import com.virtualsblog.project.presentation.ui.screen.auth.terms.TermsAndConditionsScreen
+import com.virtualsblog.project.presentation.ui.screen.auth.verifyotp.VerifyOtpScreen
+import com.virtualsblog.project.presentation.ui.screen.category.list.CategoriesScreen
+import com.virtualsblog.project.presentation.ui.screen.category.posts.CategoryPostsScreen
 import com.virtualsblog.project.presentation.ui.screen.home.HomeScreen
-import com.virtualsblog.project.presentation.ui.screen.splash.SplashScreen
 import com.virtualsblog.project.presentation.ui.screen.post.create.CreatePostScreen
 import com.virtualsblog.project.presentation.ui.screen.post.detail.PostDetailScreen
 import com.virtualsblog.project.presentation.ui.screen.post.edit.EditPostScreen
 import com.virtualsblog.project.presentation.ui.screen.post.list.PostListScreen
-import com.virtualsblog.project.presentation.ui.screen.auth.changepassword.ChangePasswordScreen
-import com.virtualsblog.project.presentation.ui.screen.category.list.CategoriesScreen
-import com.virtualsblog.project.presentation.ui.screen.category.posts.CategoryPostsScreen
-import com.virtualsblog.project.presentation.ui.screen.search.SearchScreen // *** ADDED IMPORT FOR SEARCH SCREEN ***
+import com.virtualsblog.project.presentation.ui.screen.search.SearchScreen
+import com.virtualsblog.project.presentation.ui.screen.splash.SplashScreen
+// *** NEW IMPORT FOR AUTHOR POSTS SCREEN ***
+import com.virtualsblog.project.presentation.ui.screen.authorposts.AuthorPostsScreen
 import java.net.URLDecoder
 import java.net.URLEncoder
 import java.nio.charset.StandardCharsets
@@ -37,7 +39,7 @@ fun BlogNavGraph(
         navController = navController,
         startDestination = BlogDestinations.SPLASH_ROUTE
     ) {
-        // Layar Splash
+
         composable(BlogDestinations.SPLASH_ROUTE) {
             SplashScreen(
                 onNavigateToLogin = {
@@ -53,7 +55,6 @@ fun BlogNavGraph(
             )
         }
 
-        // Layar Autentikasi
         composable(BlogDestinations.LOGIN_ROUTE) {
             LoginScreen(
                 onNavigateToRegister = {
@@ -85,6 +86,7 @@ fun BlogNavGraph(
                 }
             )
         }
+
 
         composable(BlogDestinations.TERMS_AND_CONDITIONS_ROUTE) {
             TermsAndConditionsScreen(
@@ -145,8 +147,6 @@ fun BlogNavGraph(
                 }
             )
         }
-
-        // Layar Utama Aplikasi
         composable(BlogDestinations.HOME_ROUTE) {
             HomeScreen(
                 onNavigateToProfile = {
@@ -170,7 +170,7 @@ fun BlogNavGraph(
                 onNavigateToCategories = {
                     navController.navigate(BlogDestinations.CATEGORIES_ROUTE)
                 },
-                onNavigateToSearch = { // *** ADDED NAVIGATION TO SEARCH ***
+                onNavigateToSearch = {
                     navController.navigate(BlogDestinations.SEARCH_ROUTE)
                 }
             )
@@ -200,6 +200,7 @@ fun BlogNavGraph(
                 }
             )
         }
+
 
         composable(BlogDestinations.CREATE_POST_ROUTE) {
             CreatePostScreen(
@@ -268,9 +269,8 @@ fun BlogNavGraph(
             CategoriesScreen(
                 onNavigateBack = { navController.popBackStack() },
                 onNavigateToCategoryPosts = { categoryId, categoryName ->
-                    val encodedCategoryName = URLEncoder.encode(categoryName, StandardCharsets.UTF_8.toString())
                     navController.navigate(
-                        BlogDestinations.categoryPostsRoute(categoryId, encodedCategoryName)
+                        BlogDestinations.categoryPostsRoute(categoryId, categoryName)
                     )
                 }
             )
@@ -296,26 +296,52 @@ fun BlogNavGraph(
             )
         }
 
-        // *** NEW COMPOSABLE FOR SEARCH SCREEN ***
+
+        // Search Screen
         composable(BlogDestinations.SEARCH_ROUTE) {
             SearchScreen(
                 onNavigateBack = { navController.popBackStack() },
                 onNavigateToPostDetail = { postId ->
                     navController.navigate(BlogDestinations.postDetailRoute(postId))
                 },
-                onNavigateToUserProfile = { userId ->
-                    // Navigasi ke profil pengguna. Anda mungkin perlu membuat route khusus
-                    // jika ingin menampilkan profil pengguna lain, atau sesuaikan.
-                    // Untuk saat ini, navigasi ke profil pengguna saat ini jika userId cocok,
-                    // atau handle berbeda jika tidak.
-                    // Contoh sederhana:
-                    navController.navigate(BlogDestinations.PROFILE_ROUTE) // Sesuaikan jika perlu
+                // *** MODIFIED NAVIGATION FOR USER PROFILE CLICK FROM SEARCH ***
+                onNavigateToUserProfile = { authorId, authorName ->
+                    // URL encode the authorName to handle special characters in navigation routes
+                    navController.navigate(
+                        BlogDestinations.authorPostsRoute(authorId, authorName)
+                    )
                 },
                 onNavigateToCategoryPosts = { categoryId, categoryName ->
-                    val encodedCategoryName = URLEncoder.encode(categoryName, StandardCharsets.UTF_8.toString())
                     navController.navigate(
-                        BlogDestinations.categoryPostsRoute(categoryId, encodedCategoryName)
+                        BlogDestinations.categoryPostsRoute(categoryId, categoryName)
                     )
+                }
+            )
+        }
+
+        // *** NEW COMPOSABLE FOR AUTHOR POSTS SCREEN ***
+        composable(
+            route = BlogDestinations.AUTHOR_POSTS_WITH_ID_AND_NAME,
+            arguments = listOf(
+                navArgument(BlogDestinations.Args.AUTHOR_ID) { type = NavType.StringType },
+                navArgument(BlogDestinations.Args.AUTHOR_NAME) { type = NavType.StringType }
+            )
+        ) { backStackEntry ->
+            val authorId = backStackEntry.arguments?.getString(BlogDestinations.Args.AUTHOR_ID) ?: ""
+            // Decode the authorName here as it was encoded before navigation
+            val encodedAuthorName = backStackEntry.arguments?.getString(BlogDestinations.Args.AUTHOR_NAME) ?: "Pengguna"
+            val authorName = try {
+                URLDecoder.decode(encodedAuthorName, StandardCharsets.UTF_8.toString())
+            } catch (e: Exception) {
+                "Pengguna" // Fallback if decoding fails
+            }
+
+
+            AuthorPostsScreen(
+                authorName = authorName,
+                onNavigateBack = { navController.popBackStack() },
+                onNavigateToPostDetail = { postId ->
+                    navController.navigate(BlogDestinations.postDetailRoute(postId))
                 }
             )
         }

--- a/app/src/main/java/com/virtualsblog/project/presentation/ui/screen/authorposts/AuthorPostsScreen.kt
+++ b/app/src/main/java/com/virtualsblog/project/presentation/ui/screen/authorposts/AuthorPostsScreen.kt
@@ -1,0 +1,121 @@
+package com.virtualsblog.project.presentation.ui.screen.authorposts
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.HeartBroken
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import com.virtualsblog.project.presentation.ui.component.PostCard
+import com.virtualsblog.project.presentation.ui.component.LoadingIndicator
+import com.virtualsblog.project.presentation.ui.component.ErrorMessage
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun AuthorPostsScreen(
+    authorName: String, // Received from NavGraph (already decoded)
+    onNavigateBack: () -> Unit,
+    onNavigateToPostDetail: (String) -> Unit,
+    viewModel: AuthorPostsViewModel = hiltViewModel()
+) {
+    val uiState by viewModel.uiState.collectAsState()
+    var showDislikeDialog by remember { mutableStateOf(false) }
+    var postToDislike by remember { mutableStateOf<String?>(null) }
+
+    if (showDislikeDialog && postToDislike != null) {
+        AlertDialog(
+            onDismissRequest = {
+                showDislikeDialog = false
+                postToDislike = null
+            },
+            title = { Text("Batalkan Like?", style = MaterialTheme.typography.titleLarge, fontWeight = FontWeight.Bold) },
+            text = { Text("Apakah Anda yakin ingin membatalkan like pada postingan ini?", style = MaterialTheme.typography.bodyMedium) },
+            confirmButton = {
+                Button(
+                    onClick = {
+                        postToDislike?.let { postId -> viewModel.performDislike(postId) }
+                        showDislikeDialog = false
+                        postToDislike = null
+                    },
+                    colors = ButtonDefaults.buttonColors(containerColor = MaterialTheme.colorScheme.error)
+                ) { Text("Ya, Batalkan Like") }
+            },
+            dismissButton = {
+                TextButton(onClick = { showDislikeDialog = false; postToDislike = null }) { Text("Batal") }
+            },
+            icon = { Icon(Icons.Default.HeartBroken, contentDescription = null, tint = MaterialTheme.colorScheme.error, modifier = Modifier.size(32.dp)) }
+        )
+    }
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text("Postingan oleh ${uiState.authorName.ifEmpty { authorName }}", fontWeight = FontWeight.Bold, maxLines = 1) },
+                navigationIcon = {
+                    IconButton(onClick = onNavigateBack) {
+                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Kembali")
+                    }
+                },
+                colors = TopAppBarDefaults.topAppBarColors(
+                    containerColor = MaterialTheme.colorScheme.surface,
+                    titleContentColor = MaterialTheme.colorScheme.onSurface
+                )
+            )
+        }
+    ) { paddingValues ->
+        Box(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(paddingValues)
+                .background(MaterialTheme.colorScheme.background)
+        ) {
+            when {
+                uiState.isLoading && uiState.posts.isEmpty() -> LoadingIndicator(message = "Memuat postingan ${uiState.authorName.ifEmpty{authorName}}...")
+                uiState.error != null -> ErrorMessage(
+                    message = uiState.error!!,
+                    onRetry = { viewModel.loadPostsForAuthor() },
+                    modifier = Modifier.padding(16.dp).align(Alignment.Center)
+                )
+                uiState.posts.isEmpty() && !uiState.isLoading -> {
+                    Box(modifier = Modifier.fillMaxSize().padding(16.dp), contentAlignment = Alignment.Center) {
+                        Text(
+                            "${uiState.authorName.ifEmpty { authorName }} belum memiliki postingan.",
+                            style = MaterialTheme.typography.titleMedium,
+                            textAlign = TextAlign.Center
+                        )
+                    }
+                }
+                else -> {
+                    LazyColumn(
+                        contentPadding = PaddingValues(16.dp),
+                        verticalArrangement = Arrangement.spacedBy(16.dp),
+                        modifier = Modifier.fillMaxSize()
+                    ) {
+                        items(uiState.posts, key = { it.id }) { post ->
+                            PostCard(
+                                post = post,
+                                onClick = { onNavigateToPostDetail(post.id) },
+                                onLikeClick = { postId ->
+                                    viewModel.togglePostLike(postId) {
+                                        postToDislike = postId
+                                        showDislikeDialog = true
+                                    }
+                                },
+                                isLikeLoading = uiState.likingPostIds.contains(post.id)
+                            )
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/virtualsblog/project/presentation/ui/screen/authorposts/AuthorPostsUiState.kt
+++ b/app/src/main/java/com/virtualsblog/project/presentation/ui/screen/authorposts/AuthorPostsUiState.kt
@@ -1,0 +1,11 @@
+package com.virtualsblog.project.presentation.ui.screen.authorposts
+
+import com.virtualsblog.project.domain.model.Post
+
+data class AuthorPostsUiState(
+    val isLoading: Boolean = false,
+    val posts: List<Post> = emptyList(),
+    val authorName: String = "",
+    val error: String? = null,
+    val likingPostIds: Set<String> = emptySet() // For like button loading state
+)

--- a/app/src/main/java/com/virtualsblog/project/presentation/ui/screen/authorposts/AuthorPostsViewModel.kt
+++ b/app/src/main/java/com/virtualsblog/project/presentation/ui/screen/authorposts/AuthorPostsViewModel.kt
@@ -1,0 +1,126 @@
+package com.virtualsblog.project.presentation.ui.screen.authorposts
+
+import androidx.lifecycle.SavedStateHandle
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.virtualsblog.project.domain.usecase.blog.GetPostsByAuthorIdUseCase
+import com.virtualsblog.project.domain.usecase.blog.ToggleLikeUseCase
+import com.virtualsblog.project.presentation.ui.navigation.BlogDestinations
+import com.virtualsblog.project.util.Resource
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+import java.net.URLDecoder
+import java.nio.charset.StandardCharsets
+
+@HiltViewModel
+class AuthorPostsViewModel @Inject constructor(
+    private val getPostsByAuthorIdUseCase: GetPostsByAuthorIdUseCase,
+    private val toggleLikeUseCase: ToggleLikeUseCase,
+    savedStateHandle: SavedStateHandle
+) : ViewModel() {
+
+    private val authorId: String = savedStateHandle.get<String>(BlogDestinations.Args.AUTHOR_ID) ?: ""
+    private val encodedAuthorName: String = savedStateHandle.get<String>(BlogDestinations.Args.AUTHOR_NAME) ?: "Pengguna"
+    private val authorNameArg: String = try {
+        URLDecoder.decode(encodedAuthorName, StandardCharsets.UTF_8.toString())
+    } catch (e: Exception) {
+        "Pengguna" // Fallback if decoding fails
+    }
+
+
+    private val _uiState = MutableStateFlow(AuthorPostsUiState(authorName = authorNameArg))
+    val uiState: StateFlow<AuthorPostsUiState> = _uiState.asStateFlow()
+
+    init {
+        if (authorId.isNotBlank()) {
+            loadPostsForAuthor(authorId)
+        } else {
+            _uiState.value = _uiState.value.copy(isLoading = false, error = "ID Author tidak valid.")
+        }
+    }
+
+    fun loadPostsForAuthor(authId: String = authorId) {
+        viewModelScope.launch {
+            _uiState.value = _uiState.value.copy(isLoading = true, error = null)
+            getPostsByAuthorIdUseCase(authId).collect { result ->
+                when (result) {
+                    is Resource.Success -> {
+                        _uiState.value = _uiState.value.copy(
+                            isLoading = false,
+                            posts = result.data ?: emptyList(),
+                            error = null
+                            // authorName can also be updated here if posts have consistent author name
+                        )
+                    }
+                    is Resource.Error -> {
+                        _uiState.value = _uiState.value.copy(
+                            isLoading = false,
+                            error = result.message ?: "Gagal memuat postingan dari author ini."
+                        )
+                    }
+                    is Resource.Loading -> {
+                        _uiState.value = _uiState.value.copy(isLoading = true)
+                    }
+                }
+            }
+        }
+    }
+
+    fun togglePostLike(postId: String, onConfirmDislike: () -> Unit) {
+        val currentPosts = _uiState.value.posts
+        val postIndex = currentPosts.indexOfFirst { it.id == postId }
+        if (postIndex == -1) return
+
+        val currentPost = currentPosts[postIndex]
+        if (currentPost.isLiked) {
+            onConfirmDislike()
+            return
+        }
+        performLikeToggle(postId)
+    }
+
+    fun performDislike(postId: String) {
+        performLikeToggle(postId)
+    }
+
+    private fun performLikeToggle(postId: String) {
+        viewModelScope.launch {
+            _uiState.value = _uiState.value.copy(likingPostIds = _uiState.value.likingPostIds + postId)
+            toggleLikeUseCase(postId).collect { resource ->
+                when (resource) {
+                    is Resource.Success -> {
+                        val isLiked = resource.data?.first ?: false
+                        _uiState.value = _uiState.value.copy(
+                            posts = _uiState.value.posts.map {
+                                if (it.id == postId) {
+                                    it.copy(
+                                        isLiked = isLiked,
+                                        likes = if (isLiked) it.likes + 1 else kotlin.math.max(0, it.likes - 1)
+                                    )
+                                } else it
+                            },
+                            likingPostIds = _uiState.value.likingPostIds - postId
+                        )
+                    }
+                    is Resource.Error -> {
+                        _uiState.value = _uiState.value.copy(
+                            error = resource.message ?: "Gagal mengubah status like.",
+                            likingPostIds = _uiState.value.likingPostIds - postId
+                        )
+                    }
+                    is Resource.Loading -> {
+                        // Handled
+                    }
+                }
+            }
+        }
+    }
+
+    fun clearError() {
+        _uiState.value = _uiState.value.copy(error = null)
+    }
+}

--- a/app/src/main/java/com/virtualsblog/project/presentation/ui/screen/search/SearchScreen.kt
+++ b/app/src/main/java/com/virtualsblog/project/presentation/ui/screen/search/SearchScreen.kt
@@ -37,7 +37,7 @@ import com.virtualsblog.project.util.Constants
 fun SearchScreen(
     onNavigateBack: () -> Unit,
     onNavigateToPostDetail: (String) -> Unit,
-    onNavigateToUserProfile: (String) -> Unit, // Assuming user ID for navigation
+    onNavigateToUserProfile: (authorId: String, authorName: String) -> Unit, // *** MODIFIED SIGNATURE ***
     onNavigateToCategoryPosts: (categoryId: String, categoryName: String) -> Unit,
     viewModel: SearchViewModel = hiltViewModel()
 ) {
@@ -59,7 +59,7 @@ fun SearchScreen(
                         placeholder = { Text(Constants.SEARCH_HINT) },
                         modifier = Modifier
                             .fillMaxWidth()
-                            .padding(end = 16.dp) // Give space for clear button if any
+                            .padding(end = 16.dp)
                             .focusRequester(focusRequester),
                         singleLine = true,
                         keyboardOptions = KeyboardOptions.Default.copy(imeAction = ImeAction.Search),
@@ -104,7 +104,7 @@ fun SearchScreen(
                 ErrorMessage(
                     message = uiState.error!!,
                     onRetry = { viewModel.performSearch() },
-                    modifier = Modifier.padding(16.dp)
+                    modifier = Modifier.padding(16.dp).align(Alignment.CenterHorizontally)
                 )
             } else if (uiState.isInitialState) {
                 Box(modifier = Modifier.fillMaxSize().padding(16.dp), contentAlignment = Alignment.Center) {
@@ -143,7 +143,8 @@ fun SearchScreen(
                         if (results.users.isNotEmpty()) {
                             item { SearchSectionHeader("Pengguna") }
                             items(results.users, key = { it.id }) { user ->
-                                UserResultItem(user = user, onClick = { onNavigateToUserProfile(user.id) })
+                                // *** MODIFIED onClick TO PASS BOTH ID AND NAME ***
+                                UserResultItem(user = user, onClick = { onNavigateToUserProfile(user.id, user.fullname.ifEmpty { user.username }) })
                             }
                         }
                         if (results.categories.isNotEmpty()) {
@@ -156,7 +157,6 @@ fun SearchScreen(
                             item { SearchSectionHeader("Postingan") }
                             items(results.posts, key = { it.id }) { post ->
                                 PostCard(post = post, onClick = { onNavigateToPostDetail(post.id) })
-                                // Like functionality can be added here if needed, similar to HomeScreen
                             }
                         }
                     }
@@ -189,10 +189,10 @@ private fun UserResultItem(user: User, onClick: () -> Unit) {
             modifier = Modifier.padding(16.dp),
             verticalAlignment = Alignment.CenterVertically
         ) {
-            UserAvatar(userName = user.fullname, imageUrl = user.image, size = 48.dp)
+            UserAvatar(userName = user.fullname.ifEmpty { user.username }, imageUrl = user.image, size = 48.dp)
             Spacer(modifier = Modifier.width(16.dp))
             Column {
-                Text(user.fullname, style = MaterialTheme.typography.titleMedium, fontWeight = FontWeight.SemiBold)
+                Text(user.fullname.ifEmpty { user.username }, style = MaterialTheme.typography.titleMedium, fontWeight = FontWeight.SemiBold)
                 Text("@${user.username}", style = MaterialTheme.typography.bodyMedium, color = MaterialTheme.colorScheme.onSurfaceVariant)
             }
         }


### PR DESCRIPTION
This commit introduces a new feature allowing users to view all posts made by a specific author.

Key changes include:

- Added `AuthorPostsScreen`: Displays a list of posts filtered by author ID.
  - Includes `AuthorPostsViewModel` to handle data fetching and UI state (`AuthorPostsUiState`).
  - Uses `GetPostsByAuthorIdUseCase` to retrieve author-specific posts.
  - Implements like/dislike functionality for posts on this screen.

- Updated Navigation:
  - Defined new route `AUTHOR_POSTS_ROUTE` in `BlogDestinations.kt` with `authorId` and `authorName` arguments.
  - Modified `BlogNavGraph.kt`:
    - Added `AuthorPostsScreen` as a new destination.
    - Updated `SearchScreen`'s `onNavigateToUserProfile` lambda to navigate to `AuthorPostsScreen` instead of the generic profile screen, passing the clicked author's ID and name.
  - Modified `SearchScreen.kt`:
    - Updated the `onNavigateToUserProfile` lambda signature to accept `authorId` and `authorName`.
    - The `UserResultItem` now passes both `user.id` and `user.fullname` (or `user.username`) when clicked.

- Backend Integration:
  - Added `getPostsByAuthorId` method to `BlogApi.kt` (utilizing the existing `GET /authors/{id}` endpoint [cite: 92, 93]).
  - Implemented `getPostsByAuthorId` in `BlogRepository.kt` and `BlogRepositoryImpl.kt`.
  - Created `GetPostsByAuthorIdUseCase.kt` for fetching posts by author.
  - Updated `UseCaseModule.kt` to provide the new use case.

This change enhances user experience by allowing direct navigation from search results to an author's dedicated post list, improving content discovery for specific authors.