### PR TITLE
feat: Implement Edit Profile Screen

### DIFF
--- a/app/src/main/java/com/virtualsblog/project/presentation/ui/screen/auth/editprofile/EditProfileScreen.kt
+++ b/app/src/main/java/com/virtualsblog/project/presentation/ui/screen/auth/editprofile/EditProfileScreen.kt
@@ -1,15 +1,38 @@
 package com.virtualsblog.project.presentation.ui.screen.auth.editprofile
 
+import androidx.compose.animation.*
+import androidx.compose.animation.core.*
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.KeyboardActions
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.*
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.focus.FocusDirection
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalFocusManager
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.input.ImeAction
+import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
 import androidx.hilt.navigation.compose.hiltViewModel
-import com.virtualsblog.project.presentation.ui.component.CustomTextField
+import com.virtualsblog.project.presentation.ui.theme.*
+import com.virtualsblog.project.util.showToast
+import kotlinx.coroutines.delay
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -18,67 +41,564 @@ fun EditProfileScreen(
     viewModel: EditProfileViewModel = hiltViewModel()
 ) {
     val uiState by viewModel.uiState.collectAsState()
+    val context = LocalContext.current
+    val focusManager = LocalFocusManager.current
 
+    // State untuk form
+    var fullname by remember { mutableStateOf("") }
+    var username by remember { mutableStateOf("") }
+    var email by remember { mutableStateOf("") }
+
+    // State untuk animasi loading
+    var showSuccessAnimation by remember { mutableStateOf(false) }
+
+    // Validasi real-time
+    val isFullnameValid = fullname.length >= 3
+    val isUsernameValid = username.length >= 6 && username.matches(Regex("^[a-zA-Z0-9_]+$"))
+    val isEmailValid = android.util.Patterns.EMAIL_ADDRESS.matcher(email).matches()
+    val isFormValid = isFullnameValid && isUsernameValid && isEmailValid
+
+    // Update form saat data profil dimuat
+    LaunchedEffect(uiState.fullname, uiState.username, uiState.email) {
+        if (uiState.fullname.isNotEmpty()) fullname = uiState.fullname
+        if (uiState.username.isNotEmpty()) username = uiState.username
+        if (uiState.email.isNotEmpty()) email = uiState.email
+    }
+
+    // Handle sukses dengan animasi loading
     LaunchedEffect(uiState.isSuccess) {
         if (uiState.isSuccess) {
+            showSuccessAnimation = true
+            context.showToast("Profil berhasil diperbarui!")
+            delay(2000) // Tampilkan animasi selama 2 detik
             onNavigateBack()
         }
     }
 
-    Scaffold(
-        topBar = {
-            TopAppBar(
-                title = { Text("Edit Profil") },
-                navigationIcon = {
-                    IconButton(onClick = onNavigateBack) {
-                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Kembali")
-                    }
-                }
-            )
+    // Handle error dengan toast
+    LaunchedEffect(uiState.error) {
+        uiState.error?.let {
+            context.showToast(it)
         }
-    ) { paddingValues ->
+    }
+
+    Box(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(color = Background)
+    ) {
         Column(
-            modifier = Modifier
-                .padding(paddingValues)
-                .padding(16.dp)
-                .fillMaxSize(),
-            horizontalAlignment = Alignment.CenterHorizontally,
-            verticalArrangement = Arrangement.spacedBy(16.dp)
+            modifier = Modifier.fillMaxSize()
         ) {
-            if (uiState.isLoading && uiState.fullname.isEmpty()) {
-                CircularProgressIndicator()
-            } else {
-                CustomTextField(
-                    value = uiState.fullname,
-                    onValueChange = viewModel::onFullNameChange,
-                    label = "Nama Lengkap",
-                    modifier = Modifier.fillMaxWidth()
+            // Header dengan gradient background (konsisten dengan Profile)
+            Box(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .background(
+                        brush = Brush.verticalGradient(
+                            colors = listOf(
+                                Primary,
+                                PrimaryVariant.copy(alpha = 0.9f)
+                            ),
+                            startY = 0f,
+                            endY = 300f
+                        )
+                    )
+            ) {
+                TopAppBar(
+                    title = {
+                        Text(
+                            text = "Edit Profil",
+                            fontWeight = FontWeight.Bold,
+                            color = OnPrimary,
+                            fontSize = 22.sp
+                        )
+                    },
+                    navigationIcon = {
+                        IconButton(onClick = onNavigateBack) {
+                            Icon(
+                                Icons.AutoMirrored.Filled.ArrowBack,
+                                contentDescription = "Kembali",
+                                tint = OnPrimary
+                            )
+                        }
+                    },
+                    colors = TopAppBarDefaults.topAppBarColors(
+                        containerColor = Color.Transparent
+                    )
                 )
-                CustomTextField(
-                    value = uiState.username,
-                    onValueChange = viewModel::onUserNameChange,
-                    label = "Username",
-                    modifier = Modifier.fillMaxWidth()
-                )
-                CustomTextField(
-                    value = uiState.email,
-                    onValueChange = viewModel::onEmailChange,
-                    label = "Email",
-                    modifier = Modifier.fillMaxWidth()
-                )
-                Button(
-                    onClick = { viewModel.saveProfile() },
-                    modifier = Modifier.fillMaxWidth(),
-                    enabled = !uiState.isLoading
+            }
+
+            if (uiState.isLoading && fullname.isEmpty()) {
+                // Loading saat pertama kali load
+                Box(
+                    modifier = Modifier.fillMaxSize(),
+                    contentAlignment = Alignment.Center
                 ) {
-                    if (uiState.isLoading) {
-                        CircularProgressIndicator(modifier = Modifier.size(24.dp))
-                    } else {
-                        Text("Simpan Perubahan")
+                    Column(
+                        horizontalAlignment = Alignment.CenterHorizontally
+                    ) {
+                        CircularProgressIndicator(
+                            color = Primary,
+                            modifier = Modifier.size(48.dp),
+                            strokeWidth = 3.dp
+                        )
+                        Spacer(modifier = Modifier.height(16.dp))
+                        Text(
+                            text = "Memuat data profil...",
+                            style = MaterialTheme.typography.bodyMedium,
+                            color = TextSecondary
+                        )
                     }
                 }
-                uiState.error?.let {
-                    Text(text = it, color = MaterialTheme.colorScheme.error)
+            } else {
+                Column(
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .verticalScroll(rememberScrollState())
+                        .padding(horizontal = 20.dp),
+                    horizontalAlignment = Alignment.CenterHorizontally
+                ) {
+                    Spacer(modifier = Modifier.height(32.dp))
+
+                    // Ikon Edit yang lebih menarik
+                    Box(
+                        modifier = Modifier
+                            .size(100.dp)
+                            .background(
+                                brush = Brush.radialGradient(
+                                    colors = listOf(
+                                        Primary.copy(alpha = 0.7f),
+                                        Primary.copy(alpha = 0.4f),
+                                        Primary.copy(alpha = 0.1f)
+                                    ),
+                                    radius = 300f
+                                ),
+                                shape = RoundedCornerShape(50.dp)
+                            ),
+                        contentAlignment = Alignment.Center
+                    ) {
+                        Icon(
+                            imageVector = Icons.Default.Edit,
+                            contentDescription = null,
+                            modifier = Modifier.size(48.dp),
+                            tint = Primary
+                        )
+                    }
+
+                    Spacer(modifier = Modifier.height(24.dp))
+
+                    Text(
+                        text = "Edit Profil",
+                        style = MaterialTheme.typography.headlineSmall,
+                        fontWeight = FontWeight.Bold,
+                        color = TextPrimary,
+                        fontSize = 24.sp
+                    )
+
+                    Spacer(modifier = Modifier.height(8.dp))
+
+                    Text(
+                        text = "Perbarui informasi profil Anda di bawah ini.",
+                        style = MaterialTheme.typography.bodyLarge,
+                        color = TextSecondary,
+                        textAlign = TextAlign.Center,
+                        fontSize = 16.sp
+                    )
+
+                    Spacer(modifier = Modifier.height(32.dp))
+
+                    // Card untuk form input
+                    Card(
+                        modifier = Modifier.fillMaxWidth(),
+                        shape = RoundedCornerShape(16.dp),
+                        colors = CardDefaults.cardColors(
+                            containerColor = Surface
+                        ),
+                        elevation = CardDefaults.cardElevation(defaultElevation = 4.dp)
+                    ) {
+                        Column(
+                            modifier = Modifier.padding(horizontal = 24.dp, vertical = 20.dp),
+                            verticalArrangement = Arrangement.spacedBy(8.dp)
+                        ) {
+                            // Field Nama Lengkap
+                            OutlinedTextField(
+                                value = fullname,
+                                onValueChange = { fullname = it },
+                                label = {
+                                    Text(
+                                        "Nama Lengkap",
+                                        color = Primary.copy(alpha = 0.8f)
+                                    )
+                                },
+                                leadingIcon = {
+                                    Icon(
+                                        imageVector = Icons.Default.Person,
+                                        contentDescription = null,
+                                        tint = Primary
+                                    )
+                                },
+                                modifier = Modifier.fillMaxWidth(),
+                                singleLine = true,
+                                keyboardOptions = KeyboardOptions(
+                                    keyboardType = KeyboardType.Text,
+                                    imeAction = ImeAction.Next
+                                ),
+                                keyboardActions = KeyboardActions(
+                                    onNext = { focusManager.moveFocus(FocusDirection.Down) }
+                                ),
+                                isError = fullname.isNotEmpty() && !isFullnameValid,
+                                supportingText = {
+                                    if (fullname.isNotEmpty() && !isFullnameValid) {
+                                        Text(
+                                            text = "Nama lengkap minimal 3 karakter",
+                                            color = Error,
+                                            fontSize = 12.sp
+                                        )
+                                    }
+                                },
+                                shape = RoundedCornerShape(12.dp),
+                                colors = OutlinedTextFieldDefaults.colors(
+                                    focusedBorderColor = Primary,
+                                    unfocusedBorderColor = Primary.copy(alpha = 0.5f),
+                                    focusedLabelColor = Primary,
+                                    cursorColor = Primary,
+                                    focusedContainerColor = Primary.copy(alpha = 0.05f),
+                                    unfocusedContainerColor = SurfaceVariant.copy(alpha = 0.5f),
+                                    errorBorderColor = Error,
+                                    errorCursorColor = Error
+                                )
+                            )
+
+                            // Field Username
+                            OutlinedTextField(
+                                value = username,
+                                onValueChange = { username = it },
+                                label = {
+                                    Text(
+                                        "Username",
+                                        color = Primary.copy(alpha = 0.8f)
+                                    )
+                                },
+                                leadingIcon = {
+                                    Icon(
+                                        imageVector = Icons.Default.AlternateEmail,
+                                        contentDescription = null,
+                                        tint = Primary
+                                    )
+                                },
+                                modifier = Modifier.fillMaxWidth(),
+                                singleLine = true,
+                                keyboardOptions = KeyboardOptions(
+                                    keyboardType = KeyboardType.Text,
+                                    imeAction = ImeAction.Next
+                                ),
+                                keyboardActions = KeyboardActions(
+                                    onNext = { focusManager.moveFocus(FocusDirection.Down) }
+                                ),
+                                isError = username.isNotEmpty() && !isUsernameValid,
+                                supportingText = {
+                                    if (username.isNotEmpty() && !isUsernameValid) {
+                                        Text(
+                                            text = if (username.length < 6) "Username minimal 6 karakter"
+                                            else "Hanya boleh huruf, angka, dan garis bawah",
+                                            color = Error,
+                                            fontSize = 12.sp
+                                        )
+                                    }
+                                },
+                                shape = RoundedCornerShape(12.dp),
+                                colors = OutlinedTextFieldDefaults.colors(
+                                    focusedBorderColor = Primary,
+                                    unfocusedBorderColor = Primary.copy(alpha = 0.5f),
+                                    focusedLabelColor = Primary,
+                                    cursorColor = Primary,
+                                    focusedContainerColor = Primary.copy(alpha = 0.05f),
+                                    unfocusedContainerColor = SurfaceVariant.copy(alpha = 0.5f),
+                                    errorBorderColor = Error,
+                                    errorCursorColor = Error
+                                )
+                            )
+
+                            // Field Email
+                            OutlinedTextField(
+                                value = email,
+                                onValueChange = { email = it },
+                                label = {
+                                    Text(
+                                        "Email",
+                                        color = Primary.copy(alpha = 0.8f)
+                                    )
+                                },
+                                leadingIcon = {
+                                    Icon(
+                                        imageVector = Icons.Default.Email,
+                                        contentDescription = null,
+                                        tint = Primary
+                                    )
+                                },
+                                modifier = Modifier.fillMaxWidth(),
+                                singleLine = true,
+                                keyboardOptions = KeyboardOptions(
+                                    keyboardType = KeyboardType.Email,
+                                    imeAction = ImeAction.Done
+                                ),
+                                keyboardActions = KeyboardActions(
+                                    onDone = {
+                                        focusManager.clearFocus()
+                                        if (isFormValid) {
+                                            viewModel.updateProfile(fullname, email, username)
+                                        }
+                                    }
+                                ),
+                                isError = email.isNotEmpty() && !isEmailValid,
+                                supportingText = {
+                                    if (email.isNotEmpty() && !isEmailValid) {
+                                        Text(
+                                            text = "Format email tidak valid",
+                                            color = Error,
+                                            fontSize = 12.sp
+                                        )
+                                    }
+                                },
+                                shape = RoundedCornerShape(12.dp),
+                                colors = OutlinedTextFieldDefaults.colors(
+                                    focusedBorderColor = Primary,
+                                    unfocusedBorderColor = Primary.copy(alpha = 0.5f),
+                                    focusedLabelColor = Primary,
+                                    cursorColor = Primary,
+                                    focusedContainerColor = Primary.copy(alpha = 0.05f),
+                                    unfocusedContainerColor = SurfaceVariant.copy(alpha = 0.5f),
+                                    errorBorderColor = Error,
+                                    errorCursorColor = Error
+                                )
+                            )
+                        }
+                    }
+
+                    Spacer(modifier = Modifier.height(28.dp))
+
+                    // Tombol Simpan dengan animasi
+                    Button(
+                        onClick = {
+                            if (isFormValid) {
+                                viewModel.updateProfile(fullname, email, username)
+                            }
+                        },
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .height(54.dp),
+                        shape = RoundedCornerShape(12.dp),
+                        colors = ButtonDefaults.buttonColors(
+                            containerColor = Primary,
+                            contentColor = OnPrimary
+                        ),
+                        enabled = !uiState.isLoading && isFormValid,
+                        elevation = ButtonDefaults.buttonElevation(
+                            defaultElevation = 4.dp,
+                            pressedElevation = 8.dp
+                        )
+                    ) {
+                        if (uiState.isLoading) {
+                            CircularProgressIndicator(
+                                modifier = Modifier.size(24.dp),
+                                color = OnPrimary,
+                                strokeWidth = 2.5.dp
+                            )
+                            Spacer(modifier = Modifier.width(12.dp))
+                            Text(
+                                "Menyimpan...",
+                                fontWeight = FontWeight.SemiBold,
+                                fontSize = 16.sp
+                            )
+                        } else {
+                            Icon(
+                                imageVector = Icons.Default.Save,
+                                contentDescription = null,
+                                modifier = Modifier.size(18.dp)
+                            )
+                            Spacer(modifier = Modifier.width(8.dp))
+                            Text(
+                                text = "Simpan Perubahan",
+                                fontWeight = FontWeight.SemiBold,
+                                fontSize = 16.sp
+                            )
+                        }
+                    }
+
+                    // Pesan Error dengan animasi
+                    AnimatedVisibility(
+                        visible = uiState.error != null,
+                        enter = fadeIn() + expandVertically(),
+                        exit = fadeOut() + shrinkVertically()
+                    ) {
+                        Card(
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .padding(top = 20.dp),
+                            colors = CardDefaults.cardColors(
+                                containerColor = Error.copy(alpha = 0.15f)
+                            ),
+                            shape = RoundedCornerShape(12.dp),
+                            elevation = CardDefaults.cardElevation(defaultElevation = 2.dp)
+                        ) {
+                            Row(
+                                modifier = Modifier.padding(16.dp),
+                                verticalAlignment = Alignment.CenterVertically
+                            ) {
+                                Icon(
+                                    imageVector = Icons.Default.ErrorOutline,
+                                    contentDescription = null,
+                                    tint = Error,
+                                    modifier = Modifier.size(24.dp)
+                                )
+                                Spacer(modifier = Modifier.width(12.dp))
+                                Text(
+                                    text = uiState.error ?: "",
+                                    style = MaterialTheme.typography.bodyMedium,
+                                    color = Error,
+                                    modifier = Modifier.weight(1f),
+                                    fontWeight = FontWeight.Medium,
+                                    fontSize = 15.sp
+                                )
+                            }
+                        }
+                    }
+
+                    Spacer(modifier = Modifier.height(32.dp))
+
+                    // Info Card dengan tips
+                    Card(
+                        modifier = Modifier.fillMaxWidth(),
+                        shape = RoundedCornerShape(12.dp),
+                        colors = CardDefaults.cardColors(
+                            containerColor = Primary.copy(alpha = 0.05f)
+                        ),
+                        elevation = CardDefaults.cardElevation(defaultElevation = 0.dp)
+                    ) {
+                        Column(
+                            modifier = Modifier.padding(16.dp)
+                        ) {
+                            Row(
+                                verticalAlignment = Alignment.CenterVertically
+                            ) {
+                                Icon(
+                                    imageVector = Icons.Default.Info,
+                                    contentDescription = null,
+                                    tint = Primary,
+                                    modifier = Modifier.size(20.dp)
+                                )
+                                Spacer(modifier = Modifier.width(8.dp))
+                                Text(
+                                    text = "Tips Profil",
+                                    style = MaterialTheme.typography.titleSmall,
+                                    fontWeight = FontWeight.SemiBold,
+                                    color = Primary
+                                )
+                            }
+                            Spacer(modifier = Modifier.height(12.dp))
+                            Text(
+                                text = "• Gunakan nama lengkap yang mudah dikenali\n• Username hanya boleh huruf, angka, dan garis bawah\n• Email yang valid akan membantu keamanan akun\n• Perubahan akan langsung tersimpan setelah dikonfirmasi",
+                                style = MaterialTheme.typography.bodySmall,
+                                color = TextSecondary,
+                                lineHeight = 20.sp
+                            )
+                        }
+                    }
+
+                    Spacer(modifier = Modifier.height(80.dp))
+                }
+            }
+        }
+
+        // Overlay untuk animasi sukses
+        AnimatedVisibility(
+            visible = showSuccessAnimation,
+            enter = fadeIn(animationSpec = tween(300)),
+            exit = fadeOut(animationSpec = tween(300)),
+            modifier = Modifier.fillMaxSize()
+        ) {
+            Box(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .background(Color.Black.copy(alpha = 0.7f)),
+                contentAlignment = Alignment.Center
+            ) {
+                Card(
+                    shape = RoundedCornerShape(20.dp),
+                    colors = CardDefaults.cardColors(
+                        containerColor = Surface
+                    ),
+                    elevation = CardDefaults.cardElevation(defaultElevation = 8.dp)
+                ) {
+                    Column(
+                        modifier = Modifier.padding(32.dp),
+                        horizontalAlignment = Alignment.CenterHorizontally
+                    ) {
+                        // Animasi ikon sukses
+                        val scale by animateFloatAsState(
+                            targetValue = if (showSuccessAnimation) 1f else 0f,
+                            animationSpec = spring(
+                                dampingRatio = Spring.DampingRatioMediumBouncy,
+                                stiffness = Spring.StiffnessLow
+                            ),
+                            label = "success_scale"
+                        )
+
+                        Box(
+                            modifier = Modifier
+                                .size(80.dp)
+                                .background(
+                                    color = Success.copy(alpha = 0.1f),
+                                    shape = RoundedCornerShape(40.dp)
+                                )
+                                .clip(RoundedCornerShape(40.dp)),
+                            contentAlignment = Alignment.Center
+                        ) {
+                            Icon(
+                                imageVector = Icons.Default.CheckCircle,
+                                contentDescription = null,
+                                modifier = Modifier
+                                    .size(48.dp)
+                                    .graphicsLayer {
+                                        scaleX = scale
+                                        scaleY = scale
+                                    },
+                                tint = Success
+                            )
+                        }
+
+                        Spacer(modifier = Modifier.height(16.dp))
+
+                        Text(
+                            text = "Profil Berhasil Diperbarui!",
+                            style = MaterialTheme.typography.titleLarge,
+                            fontWeight = FontWeight.Bold,
+                            color = TextPrimary,
+                            textAlign = TextAlign.Center
+                        )
+
+                        Spacer(modifier = Modifier.height(8.dp))
+
+                        Text(
+                            text = "Perubahan telah disimpan ke akun Anda",
+                            style = MaterialTheme.typography.bodyMedium,
+                            color = TextSecondary,
+                            textAlign = TextAlign.Center
+                        )
+
+                        Spacer(modifier = Modifier.height(16.dp))
+
+                        // Progress bar kecil
+                        LinearProgressIndicator(
+                            modifier = Modifier
+                                .width(100.dp)
+                                .height(4.dp)
+                                .clip(RoundedCornerShape(2.dp)),
+                            color = Primary,
+                            trackColor = Primary.copy(alpha = 0.2f)
+                        )
+                    }
                 }
             }
         }

--- a/app/src/main/java/com/virtualsblog/project/presentation/ui/screen/auth/editprofile/EditProfileViewModel.kt
+++ b/app/src/main/java/com/virtualsblog/project/presentation/ui/screen/auth/editprofile/EditProfileViewModel.kt
@@ -1,10 +1,12 @@
-
 package com.virtualsblog.project.presentation.ui.screen.auth.editprofile
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import com.virtualsblog.project.domain.repository.UserRepository
+import com.virtualsblog.project.domain.usecase.user.GetProfileUseCase
+import com.virtualsblog.project.domain.usecase.user.UpdateProfileUseCase
+import com.virtualsblog.project.util.Constants
 import com.virtualsblog.project.util.Resource
+import com.virtualsblog.project.util.ValidationUtil
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -14,7 +16,8 @@ import javax.inject.Inject
 
 @HiltViewModel
 class EditProfileViewModel @Inject constructor(
-    private val userRepository: UserRepository
+    private val getProfileUseCase: GetProfileUseCase,
+    private val updateProfileUseCase: UpdateProfileUseCase
 ) : ViewModel() {
 
     private val _uiState = MutableStateFlow(EditProfileUiState())
@@ -26,53 +29,151 @@ class EditProfileViewModel @Inject constructor(
 
     private fun loadInitialProfile() {
         viewModelScope.launch {
-            _uiState.value = _uiState.value.copy(isLoading = true)
-            when (val result = userRepository.getProfile()) {
+            _uiState.value = _uiState.value.copy(isLoading = true, error = null)
+
+            when (val result = getProfileUseCase()) {
                 is Resource.Success -> {
                     val user = result.data
                     _uiState.value = _uiState.value.copy(
                         isLoading = false,
                         fullname = user?.fullname ?: "",
                         username = user?.username ?: "",
-                        email = user?.email ?: ""
+                        email = user?.email ?: "",
+                        error = null
                     )
                 }
                 is Resource.Error -> {
                     _uiState.value = _uiState.value.copy(
                         isLoading = false,
-                        error = result.message
+                        error = result.message ?: Constants.ERROR_FAILED_LOAD_PROFILE
                     )
                 }
-                else -> {}
+                is Resource.Loading -> {
+                    _uiState.value = _uiState.value.copy(isLoading = true)
+                }
+            }
+        }
+    }
+
+    fun updateProfile(fullname: String, email: String, username: String) {
+        // Clear error sebelum validasi
+        _uiState.value = _uiState.value.copy(error = null)
+
+        // Validasi input
+        if (fullname.isBlank() || email.isBlank() || username.isBlank()) {
+            _uiState.value = _uiState.value.copy(
+                error = Constants.ERROR_REQUIRED_FIELDS,
+                isLoading = false
+            )
+            return
+        }
+
+        // Validasi nama lengkap
+        val fullnameValidation = ValidationUtil.validateFullname(fullname.trim())
+        if (!fullnameValidation.isValid) {
+            _uiState.value = _uiState.value.copy(
+                error = fullnameValidation.errorMessage ?: Constants.VALIDATION_FULLNAME_MIN_LENGTH,
+                isLoading = false
+            )
+            return
+        }
+
+        // Validasi email
+        val emailValidation = ValidationUtil.validateEmail(email.trim())
+        if (!emailValidation.isValid) {
+            _uiState.value = _uiState.value.copy(
+                error = emailValidation.errorMessage ?: Constants.VALIDATION_EMAIL_INVALID,
+                isLoading = false
+            )
+            return
+        }
+
+        // Validasi username
+        val usernameValidation = ValidationUtil.validateUsername(username.trim())
+        if (!usernameValidation.isValid) {
+            _uiState.value = _uiState.value.copy(
+                error = usernameValidation.errorMessage ?: Constants.VALIDATION_USERNAME_MIN_LENGTH,
+                isLoading = false
+            )
+            return
+        }
+
+        // Cek apakah ada perubahan
+        val currentState = _uiState.value
+        if (fullname.trim() == currentState.fullname &&
+            email.trim() == currentState.email &&
+            username.trim() == currentState.username) {
+            _uiState.value = _uiState.value.copy(
+                error = "Tidak ada perubahan yang perlu disimpan",
+                isLoading = false
+            )
+            return
+        }
+
+        // Proses update
+        viewModelScope.launch {
+            _uiState.value = _uiState.value.copy(
+                isLoading = true,
+                error = null,
+                isSuccess = false
+            )
+
+            when (val result = updateProfileUseCase(fullname.trim(), email.trim(), username.trim())) {
+                is Resource.Success -> {
+                    val updatedUser = result.data
+                    _uiState.value = _uiState.value.copy(
+                        isLoading = false,
+                        isSuccess = true,
+                        error = null,
+                        fullname = updatedUser?.fullname ?: fullname.trim(),
+                        username = updatedUser?.username ?: username.trim(),
+                        email = updatedUser?.email ?: email.trim()
+                    )
+                }
+                is Resource.Error -> {
+                    _uiState.value = _uiState.value.copy(
+                        isLoading = false,
+                        error = result.message ?: Constants.ERROR_PROFILE_UPDATE_FAILED,
+                        isSuccess = false
+                    )
+                }
+                is Resource.Loading -> {
+                    _uiState.value = _uiState.value.copy(isLoading = true)
+                }
             }
         }
     }
 
     fun onFullNameChange(newName: String) {
-        _uiState.value = _uiState.value.copy(fullname = newName)
+        _uiState.value = _uiState.value.copy(
+            fullname = newName,
+            error = null // Clear error saat user mulai edit
+        )
     }
 
     fun onUserNameChange(newUsername: String) {
-        _uiState.value = _uiState.value.copy(username = newUsername)
+        _uiState.value = _uiState.value.copy(
+            username = newUsername,
+            error = null // Clear error saat user mulai edit
+        )
     }
 
     fun onEmailChange(newEmail: String) {
-        _uiState.value = _uiState.value.copy(email = newEmail)
+        _uiState.value = _uiState.value.copy(
+            email = newEmail,
+            error = null // Clear error saat user mulai edit
+        )
     }
 
-    fun saveProfile() {
-        viewModelScope.launch {
-            _uiState.value = _uiState.value.copy(isLoading = true)
-            val currentState = _uiState.value
-            when (val result = userRepository.updateProfile(currentState.fullname, currentState.email, currentState.username)) {
-                is Resource.Success -> {
-                    _uiState.value = _uiState.value.copy(isLoading = false, isSuccess = true)
-                }
-                is Resource.Error -> {
-                    _uiState.value = _uiState.value.copy(isLoading = false, error = result.message)
-                }
-                else -> {}
-            }
-        }
+    fun clearError() {
+        _uiState.value = _uiState.value.copy(error = null)
+    }
+
+    fun clearSuccess() {
+        _uiState.value = _uiState.value.copy(isSuccess = false)
+    }
+
+    fun refreshProfile() {
+        loadInitialProfile()
     }
 }


### PR DESCRIPTION
This commit introduces the "Edit Profile" feature, allowing users to modify their personal information.

**Key changes:**

- **New Screen:** Added `EditProfileScreen.kt` for the user interface.
  - Users can update their Full Name, Username, and Email.
  - Includes input fields, a "Save Changes" button, and loading/error states.
  - Navigates back upon successful profile update.
- **ViewModel:** Created `EditProfileViewModel.kt` to handle the logic.
  - Fetches the current user profile data on initialization.
  - Provides functions to update input field values.
  - Implements `saveProfile()` to persist changes via `UserRepository`.
- **UI State:** Defined `EditProfileUiState.kt` to manage the screen's state (loading, success, error, form fields).
- **Navigation:**
  - Added a route for `EditProfileScreen` in `BlogNavGraph.kt`.
  - The bottom navigation bar is hidden on the "Edit Profile" screen.
- **Profile Screen Update:**
  - Added an "Edit" icon button on the `ProfileScreen.kt` within the "Informasi Akun" card.
  - Clicking this button navigates the user to the `EditProfileScreen`.

**Functionality:**

1. Users access the "Edit Profile" screen from their Profile page.
2. The screen pre-fills with their current profile data.
3. Users can modify their Full Name, Username, and Email.
4. Clicking "Simpan Perubahan" (Save Changes) updates the profile.
5. The screen displays loading indicators and error messages as needed.
6. Upon successful update, the user is navigated back to the previous screen (Profile Screen).